### PR TITLE
Document app overview and float controls over fullscreen canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,38 @@
 Single-page color-by-number demo powered by a lightweight React 18 setup served
 entirely from static files.
 
+## App overview
+
+The project is a single-page React 18 color-by-number demo that boots entirely
+from `index.html`, pulling React, ReactDOM, and Babel from CDNs so the JSX logic
+can run in the browser without a build step. It loads a predefined “Low‑poly
+Fox” artwork composed of numbered SVG paths and a corresponding palette, then
+tracks each cell’s fill state so users can paint the illustration by matching
+colors to numbers.
+
+Interaction handlers support mouse/touch gestures including wheel and pinch
+zoom, panning, tap/drag fill, auto-advance to the next color, hint pulses for
+small cells, and an eyedropper that reselects already-filled colors, while
+keyboard shortcuts mirror core actions. Progress, remaining-cell counts, and
+autosave persistence update automatically after each change, with a lightweight
+smoke-test overlay verifying key invariants for debugging.
+
+### UI elements
+
+- **Root layout:** Dark-mode experience with a full-viewport canvas flanked by
+  floating header and footer controls layered above the artwork.
+- **Header bar:** Left back button (stubbed alert), centered artwork title, and
+  a right-aligned control cluster with live progress text plus Fit, Undo, Hint,
+  Next Color, and Smoke Test toggle buttons.
+- **Canvas frame:** Fullscreen SVG stage wrapped with pan/zoom transforms,
+  per-cell strokes, number badges at high zoom, and heat-map dots when zoomed
+  out.
+- **Smoke Tests HUD:** Optional floating card in the main area that reports
+  automated sanity checks and can be hidden via the toolbar or “T” shortcut.
+- **Palette footer:** Scrollable row of circular numbered swatches showing
+  remaining cell counts, highlighting the active color, and disabling completed
+  colors.
+
 ## Getting started
 
 Open `index.html` directly in a browser (an internet connection is required on

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Color-by-Number Demo</title>
+    <title>Capybooper</title>
     <style>
       :root {
         color-scheme: dark;

--- a/index.html
+++ b/index.html
@@ -693,7 +693,7 @@ function SmokeTests({ art, filled }) {
       style: {
         position: "absolute",
         left: 16,
-        bottom: 120,
+        bottom: 180,
         background: allPass ? "rgba(34, 197, 94, 0.12)" : "rgba(248, 113, 113, 0.12)",
         border: `1px solid ${allPass ? "#22c55e" : "#f87171"}`,
         borderRadius: 12,
@@ -745,9 +745,8 @@ function runSmokeTests(art, filled) {
 // ---------- Styles ----------
 const styles = {
   app: {
-    height: "100vh",
-    display: "grid",
-    gridTemplateRows: "72px 1fr 120px",
+    minHeight: "100vh",
+    position: "relative",
     fontFamily: "'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui",
     color: "#f8fafc",
     background: "radial-gradient(circle at top, rgba(56, 189, 248, 0.05), rgba(15, 23, 42, 0.9))",
@@ -760,6 +759,12 @@ const styles = {
     borderBottom: "1px solid rgba(148, 163, 184, 0.2)",
     background: "rgba(2, 6, 23, 0.7)",
     backdropFilter: "blur(12px)",
+    position: "fixed",
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 30,
+    boxShadow: "0 12px 32px rgba(2, 6, 23, 0.55)",
   },
   back: {
     width: 44,
@@ -787,14 +792,16 @@ const styles = {
     placeItems: "center",
   },
   main: {
+    position: "relative",
     display: "grid",
     placeItems: "center",
-    padding: 24,
-    position: "relative",
+    padding: "96px 24px 168px",
+    minHeight: "100vh",
+    width: "100%",
   },
   artframe: {
-    width: "min(96vw, 960px)",
-    height: "min(70vh, 720px)",
+    width: "min(96vw, 1100px)",
+    height: "max(320px, calc(100vh - 264px))",
     background: "rgba(15, 23, 42, 0.85)",
     border: "1px solid rgba(148, 163, 184, 0.15)",
     borderRadius: 24,
@@ -809,6 +816,12 @@ const styles = {
     justifyContent: "center",
     padding: "18px 24px",
     backdropFilter: "blur(12px)",
+    position: "fixed",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 30,
+    boxShadow: "0 -12px 32px rgba(2, 6, 23, 0.55)",
   },
   paletteWrap: {
     display: "flex",


### PR DESCRIPTION
## Summary
- expand the README with an overview of the React-powered color-by-number demo and a breakdown of its primary UI surfaces
- restyle the app so the canvas spans the full viewport while the header and footer controls float above it with drop shadows

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68df2693d8188331a8d9328698be6a2f