### PR TITLE
Streamline canvas toolbar interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ served directly from static files.
 ## App overview
 
 The demo boots entirely from `index.html`, pulling React, ReactDOM, and Babel
-from the vendored runtime bundles so JSX can execute without a build step. It
-loads the "Capybara Forest Retreat" artwork—a lush 960×600 SVG scene with 26
-numbered regions and an 11-color palette—and keeps track of every cell you fill
-as you paint by matching colors to numbers.
+from the vendored runtime bundles so JSX can execute without a build step. The
+default scene streams directly from the annotated SVG at
+`art/capybara-lagoon.svg`, and the starter loader pulls in the segmented
+twilight companion in `art/capybara-twilight.svg` alongside the
+"Lush Green Forest Walk" reference stored in `art/lush-green-forest.svg`. The
+library reads the SVG files directly so you can jump in and paint while
+progress is tracked automatically. When opened via `file://`, the browser
+blocks direct `fetch`/XHR access to sibling files, so the generated
+`art/starter-fallbacks.js` bundle seeds the loader with the same SVG markup.
 
 Interaction handlers support mouse and touch gestures including smooth,
 cursor-anchored wheel zoom, pinch zoom, left- or right-button drag panning,

--- a/art/SEGMENTATION_GUIDE.md
+++ b/art/SEGMENTATION_GUIDE.md
@@ -1,6 +1,6 @@
 # SVG Segmentation Guide
 
-Follow these steps when exporting a new reference illustration so it can plug into the color-by-number runtime without additional cleanup.
+Follow these steps when exporting a new reference illustration so it can plug into the color-by-number runtime without additional cleanup. The segmented starters in `art/capybara-lagoon.svg`, `art/capybara-twilight.svg`, and `art/lush-green-forest.svg` are good references.
 
 1. **Use a shared canvas.** Start from a 960×600 artboard (or document the width/height clearly) and ensure the exported `<svg>` includes an explicit `viewBox` and `width`/`height` so aspect ratio stays consistent.
 2. **Include metadata.** Add `<title>` and `<desc>` elements at the top of the file that summarize the scene for assistive technology and reviewers.
@@ -11,9 +11,10 @@ Follow these steps when exporting a new reference illustration so it can plug in
    - optional `data-color-name`/`data-color-hex`/`data-color-rgba` values that seed the importer’s palette metadata
    - an embedded `<title>` node that spells out the label, e.g. `Region c1 – Color #1 (Sky Mist)` so hovering in the app reveals the tooltip.
 4. **Keep region geometry clean.** Use absolute commands (`M`, `L`, `C`, `Z`, etc.) with closed contours and avoid self-intersections. Curves are welcome for organic silhouettes, but ensure every region is watertight so the centroid sampler can locate a true interior point. Extremely thin slivers can confuse the automatic interior-point search, so widen them slightly or merge them with neighboring shapes when possible.
-5. **Avoid overlaps and gaps.** Paths must not overlap and should fully cover the illustration. Slight padding between shapes is acceptable if the background should peek through, but cells cannot intersect.
-6. **Keep fills flat.** Assign a single solid fill color per region that roughly matches the palette entry. Decorative gradients or strokes are fine in non-paintable layers, but numbered regions should stay flat for clarity.
-7. **Name the palette.** Document the palette separately (see `index.html`) with IDs, human-friendly names, and hex colors so the runtime can display swatches and instructions.
-8. **Validate before shipping.** Open the SVG in a browser and move the pointer across the regions—each should display the tooltip text and highlight clean edges. Confirm no region bleeds outside the artboard and that IDs increment without gaps. Zoom in to verify that every badge would have enough breathing room to sit comfortably inside the painted shape.
+5. **Avoid overlaps and gaps.** Paths must not overlap and should fully cover the illustration. Slight padding between shapes is acceptable if the background should peek through, but cells cannot intersect. When in doubt, tile the full canvas with contiguous regions so the background never peeks through.
+6. **Favor smooth, label-friendly shapes.** Round sharp spikes and carve smaller segments with gentle curves so each region has room for an interior badge. If a shape is small, scale it up slightly or flare the sides so the label finder can surface a bubble without being clipped by neighboring paths. When trunks or other elements should punch through layered foliage, use `fill-rule="evenodd"` cutouts (as in `lush-green-forest.svg`) so the regions stay non-overlapping while the silhouettes remain organic.
+7. **Keep fills flat.** Assign a single solid fill color per region that roughly matches the palette entry. Decorative gradients or strokes are fine in non-paintable layers, but numbered regions should stay flat for clarity.
+8. **Name the palette.** Document the palette separately (see `index.html`) with IDs, human-friendly names, and hex colors so the runtime can display swatches and instructions.
+9. **Validate before shipping.** Open the SVG in a browser and move the pointer across the regions—each should display the tooltip text and highlight clean edges. Confirm no region bleeds outside the artboard and that IDs increment without gaps. Zoom in to verify that every badge would have enough breathing room to sit comfortably inside the painted shape. When you commit new artwork, run `npm test --silent` so the automated SVG quality suite can parse the file and confirm the metadata is complete.
 
 Exporting assets with these conventions guarantees that new scenes import cleanly, display centered labels, and surface accessible tooltips in the game.

--- a/art/capybara-lagoon.svg
+++ b/art/capybara-lagoon.svg
@@ -1,0 +1,109 @@
+<!-- Capybara Lagoon Sunrise - Segmented SVG -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Capybara Lagoon Sunrise</title>
+  <desc id="desc">Layered sunrise bands over a lagoon with a stylized capybara on the shore.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="1" data-color-name="Sunrise Sky" data-color-hex="#f6bf60">
+    <title>Region c1 – Color #1 (Sunrise Sky)</title>
+    <path d="M0 0 L960 0 L960 80 C 820 70 680 68 540 72 C 380 78 220 86 0 80 Z"/>
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="1" data-color-name="Sunrise Sky" data-color-hex="#f6bf60">
+    <title>Region c2 – Color #1 (Sunrise Sky)</title>
+    <path d="M0 80 C 200 90 360 86 540 80 C 720 74 860 76 960 80 L960 148 C 820 142 680 148 520 156 C 360 166 200 164 0 148 Z"/>
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="2" data-color-name="Amber Drift" data-color-hex="#f4994c">
+    <title>Region c3 – Color #2 (Amber Drift)</title>
+    <path d="M0 148 C 160 156 320 160 520 152 C 500 176 480 198 440 212 C 320 220 160 218 0 216 Z"/>
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="2" data-color-name="Amber Drift" data-color-hex="#f4994c">
+    <title>Region c4 – Color #2 (Amber Drift)</title>
+    <path d="M520 152 C 700 150 840 146 960 148 C 940 176 900 198 860 210 C 740 220 640 220 520 214 C 520 194 520 172 520 152 Z"/>
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c5 – Color #3 (Violet Ridge)</title>
+    <path d="M0 216 C 120 228 220 232 320 230 C 300 248 260 268 210 278 C 150 286 80 284 0 280 Z"/>
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c6 – Color #3 (Violet Ridge)</title>
+    <path d="M320 230 C 440 236 520 234 640 226 C 630 250 600 268 560 276 C 480 286 400 284 320 278 C 320 258 320 244 320 230 Z"/>
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c7 – Color #3 (Violet Ridge)</title>
+    <path d="M640 226 C 760 224 860 220 960 220 C 940 240 900 260 860 272 C 780 286 700 284 640 278 C 640 256 640 240 640 226 Z"/>
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c8 – Color #4 (Forest Ridge)</title>
+    <path d="M0 280 C 100 292 200 300 320 292 C 300 312 260 328 210 336 C 150 344 80 344 0 340 Z"/>
+  </g>
+  <g id="region-c09" data-cell-id="c9" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c9 – Color #4 (Forest Ridge)</title>
+    <path d="M320 292 C 440 298 540 300 640 298 C 620 318 580 332 540 340 C 460 348 380 346 320 340 C 320 320 320 306 320 292 Z"/>
+  </g>
+  <g id="region-c10" data-cell-id="c10" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c10 – Color #4 (Forest Ridge)</title>
+    <path d="M640 298 C 760 300 860 300 960 300 C 940 320 900 332 860 340 C 780 348 700 348 640 340 C 640 320 640 308 640 298 Z"/>
+  </g>
+  <g id="region-c11" data-cell-id="c11" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c11 – Color #5 (Lagoon Light)</title>
+    <path d="M0 340 C 120 344 220 346 320 344 C 300 350 300 352 320 352 C 200 356 120 354 0 352 C 0 348 0 344 0 340 Z"/>
+  </g>
+  <g id="region-c12" data-cell-id="c12" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c12 – Color #5 (Lagoon Light)</title>
+    <path d="M320 344 C 440 346 540 344 640 342 C 640 346 640 350 640 352 C 520 356 420 356 320 352 C 320 348 320 346 320 344 Z"/>
+  </g>
+  <g id="region-c13" data-cell-id="c13" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c13 – Color #5 (Lagoon Light)</title>
+    <path d="M640 342 C 760 340 860 338 960 340 C 960 344 960 348 960 352 C 840 354 740 354 640 352 C 640 348 640 344 640 342 Z"/>
+  </g>
+  <g id="region-c14" data-cell-id="c14" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c14 – Color #5 (Lagoon Light)</title>
+    <path d="M0 352 C 120 356 220 356 320 352 C 310 364 310 372 320 376 C 200 382 120 380 0 376 C 0 364 0 358 0 352 Z"/>
+  </g>
+  <g id="region-c15" data-cell-id="c15" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c15 – Color #5 (Lagoon Light)</title>
+    <path d="M320 352 C 440 354 540 352 640 352 C 650 362 650 370 640 376 C 520 382 420 382 320 376 C 320 366 320 360 320 352 Z"/>
+  </g>
+  <g id="region-c16" data-cell-id="c16" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c16 – Color #5 (Lagoon Light)</title>
+    <path d="M640 352 C 760 352 860 350 960 352 C 960 362 960 372 960 376 C 840 380 740 380 640 376 C 640 366 640 358 640 352 Z"/>
+  </g>
+  <g id="region-c17" data-cell-id="c17" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c17 – Color #6 (Lagoon Depth)</title>
+    <path d="M0 376 C 160 382 320 388 480 384 C 480 394 480 400 480 404 C 320 408 160 404 0 404 C 0 392 0 384 0 376 Z"/>
+  </g>
+  <g id="region-c18" data-cell-id="c18" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c18 – Color #6 (Lagoon Depth)</title>
+    <path d="M480 376 C 640 382 800 380 960 376 L960 404 C 800 410 640 412 480 404 C 480 394 480 386 480 376 Z"/>
+  </g>
+  <g id="region-c19" data-cell-id="c19" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c19 – Color #6 (Lagoon Depth)</title>
+    <path d="M0 404 C 160 410 320 416 480 412 C 480 428 480 440 480 448 C 320 456 160 452 0 448 C 0 430 0 416 0 404 Z"/>
+  </g>
+  <g id="region-c20" data-cell-id="c20" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c20 – Color #6 (Lagoon Depth)</title>
+    <path d="M480 412 C 640 416 800 410 960 404 L960 448 C 820 456 680 460 520 456 C 500 454 490 448 480 448 C 480 432 480 420 480 412 Z"/>
+  </g>
+  <g id="region-c21" data-cell-id="c21" data-color-id="7" data-color-name="Shore Left" data-color-hex="#4f7d5c">
+    <title>Region c21 – Color #7 (Shore Left)</title>
+    <path d="M0 448 C 120 454 220 458 300 462 C 280 500 220 540 140 566 C 80 584 30 592 0 592 C 0 544 0 496 0 448 Z"/>
+  </g>
+  <g id="region-c22" data-cell-id="c22" data-color-id="7" data-color-name="Shore Left" data-color-hex="#4f7d5c">
+    <title>Region c22 – Color #7 (Shore Left)</title>
+    <path d="M300 462 C 360 468 420 472 520 456 C 510 486 490 514 460 540 C 420 568 360 580 300 572 C 280 540 290 500 300 462 Z"/>
+  </g>
+  <g id="region-c23" data-cell-id="c23" data-color-id="8" data-color-name="Shore Middle" data-color-hex="#6b9358">
+    <title>Region c23 – Color #8 (Shore Middle)</title>
+    <path d="M520 456 C 640 462 720 464 780 460 C 788 474 792 498 796 528 C 786 580 768 584 752 588 C 700 600 656 598 604 588 C 566 580 534 564 518 546 C 506 532 506 520 520 510 C 508 496 512 476 520 456 Z"/>
+  </g>
+  <g id="region-c24" data-cell-id="c24" data-color-id="9" data-color-name="Capy Body" data-color-hex="#7d5735">
+    <title>Region c24 – Color #9 (Capy Body)</title>
+    <path d="M520 510 C 548 470 612 440 692 434 C 744 430 768 438 780 456 C 790 474 794 498 796 528 C 798 556 786 580 752 588 C 708 600 656 598 604 588 C 566 580 534 564 518 546 C 508 532 506 518 520 510 Z"/>
+  </g>
+  <g id="region-c25" data-cell-id="c25" data-color-id="10" data-color-name="Capy Head" data-color-hex="#5e3b24">
+    <title>Region c25 – Color #10 (Capy Head)</title>
+    <path d="M780 456 C 804 438 838 438 866 460 C 894 482 904 520 892 556 C 878 594 846 608 810 600 C 800 598 796 590 796 528 C 794 500 788 474 780 456 Z"/>
+  </g>
+  <g id="region-c26" data-cell-id="c26" data-color-id="11" data-color-name="Shore Right" data-color-hex="#3f5b3b">
+    <title>Region c26 – Color #11 (Shore Right)</title>
+    <path d="M780 460 C 840 456 900 454 960 452 L960 600 C 910 600 870 598 810 600 C 846 608 878 594 892 556 C 884 520 860 488 780 460 Z"/>
+  </g>
+</svg>

--- a/art/capybara-twilight.svg
+++ b/art/capybara-twilight.svg
@@ -1,0 +1,37 @@
+<!-- Twilight Marsh Study - Segmented SVG -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Twilight Marsh Study</title>
+  <desc id="desc">Bands of twilight sky over a reflective marsh with silhouetted capybaras along the shore.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="1" data-color-name="Evening Sky" data-color-hex="#f7c59f">
+    <title>Region c1 – Color #1 (Evening Sky)</title>
+    <path d="M0 0 L960 0 L960 160 C 640 150 320 150 0 160 Z" />
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="2" data-color-name="Glow Band" data-color-hex="#f27d72">
+    <title>Region c2 – Color #2 (Glow Band)</title>
+    <path d="M0 160 C 160 180 320 180 480 185 C 640 190 800 180 960 170 L960 230 C 640 240 320 240 0 230 Z" />
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="3" data-color-name="Distant Ridge" data-color-hex="#8c5fa6">
+    <title>Region c3 – Color #3 (Distant Ridge)</title>
+    <path d="M0 230 C 200 260 400 250 600 270 C 800 290 880 270 960 280 L960 340 L0 340 Z" />
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="4" data-color-name="Low Ridge" data-color-hex="#546d7a">
+    <title>Region c4 – Color #4 (Low Ridge)</title>
+    <path d="M0 340 C 200 360 400 360 600 355 C 800 350 880 350 960 355 L960 420 L0 420 Z" />
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="5" data-color-name="River Mirror" data-color-hex="#4f9fc6">
+    <title>Region c5 – Color #5 (River Mirror)</title>
+    <path d="M0 420 C 220 440 440 450 660 440 C 800 434 880 430 960 432 L960 490 L0 490 Z" />
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="6" data-color-name="River Depth" data-color-hex="#1f6b8f">
+    <title>Region c6 – Color #6 (River Depth)</title>
+    <path d="M0 490 C 200 510 400 520 600 515 C 800 510 880 508 960 510 L960 555 L0 555 Z" />
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="7" data-color-name="Shore Glow" data-color-hex="#5d8f63">
+    <title>Region c7 – Color #7 (Shore Glow)</title>
+    <path d="M0 555 C 180 570 360 580 540 575 L540 600 L0 600 Z" />
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="8" data-color-name="Shore Shadow" data-color-hex="#2f4c45">
+    <title>Region c8 – Color #8 (Shore Shadow)</title>
+    <path d="M540 575 C 700 570 840 565 960 570 L960 600 L540 600 Z" />
+  </g>
+</svg>

--- a/art/lush-green-forest.svg
+++ b/art/lush-green-forest.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Lush Green Forest Walk</title>
+  <desc id="desc">Layered forest scene with tall trunks framing a winding path through a sunlit clearing.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="11" data-color-name="Sky Mist" data-color-hex="#d7e9f8">
+    <title>Region c1 – Color #11 (Sky Mist)</title>
+    <path d="M0 0 H960 V150 Q 870 120 760 132 Q 660 144 560 134 Q 460 124 360 136 Q 240 148 140 134 Q 60 122 0 140 Z"/>
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c2 – Color #3 (Leaf Light)</title>
+    <path d="M0 140 Q 90 110 200 126 Q 280 138 320 160 L320 220 Q 220 210 150 208 Q 70 206 0 200 Z"/>
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c3 – Color #3 (Leaf Light)</title>
+    <path d="M320 160 Q 420 136 520 136 Q 620 136 660 158 L660 220 Q 560 210 470 212 Q 380 214 320 220 Z"/>
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c4 – Color #3 (Leaf Light)</title>
+    <path d="M660 158 Q 760 136 850 126 Q 930 118 960 140 L960 220 Q 860 210 780 208 Q 700 206 660 220 Z"/>
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="1" data-color-name="Forest Deep" data-color-hex="#1f3f2c">
+    <title>Region c5 – Color #1 (Forest Deep)</title>
+    <path fill-rule="evenodd" d="M0 200 C 160 220 320 230 480 232 C 640 234 800 226 960 214 L960 320 C 820 338 680 346 540 342 C 380 338 220 328 0 308 Z M96 200 L176 200 L176 360 L96 360 Z M408 200 L488 200 L488 360 L408 360 Z M704 200 L784 200 L784 360 L704 360 Z"/>
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="4" data-color-name="Leaf Mid" data-color-hex="#7fca63">
+    <title>Region c6 – Color #4 (Leaf Mid)</title>
+    <path fill-rule="evenodd" d="M0 308 C 140 326 280 336 420 340 C 460 342 480 340 520 334 L520 400 C 420 410 320 420 220 418 C 140 416 60 408 0 400 Z M96 300 L176 300 L176 420 L96 420 Z M408 300 L488 300 L488 420 L408 420 Z"/>
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="4" data-color-name="Leaf Mid" data-color-hex="#7fca63">
+    <title>Region c7 – Color #4 (Leaf Mid)</title>
+    <path fill-rule="evenodd" d="M520 334 C 640 326 760 318 880 314 C 920 312 940 314 960 316 L960 400 C 840 412 720 420 600 416 C 540 414 500 410 460 404 L460 340 Z M704 300 L784 300 L784 420 L704 420 Z M408 300 L488 300 L488 420 L408 420 Z"/>
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="10" data-color-name="Canopy Shadow" data-color-hex="#2f4d30">
+    <title>Region c8 – Color #10 (Canopy Shadow)</title>
+    <path fill-rule="evenodd" d="M0 400 C 120 416 240 430 360 438 C 420 442 460 446 520 452 L520 500 C 420 510 320 516 220 508 C 140 502 60 488 0 472 Z M96 392 L176 392 L176 520 L96 520 Z M408 392 L488 392 L488 520 L408 520 Z"/>
+  </g>
+  <g id="region-c09" data-cell-id="c9" data-color-id="10" data-color-name="Canopy Shadow" data-color-hex="#2f4d30">
+    <title>Region c9 – Color #10 (Canopy Shadow)</title>
+    <path fill-rule="evenodd" d="M520 452 C 600 446 680 438 760 430 C 860 420 940 412 960 410 L960 500 C 880 512 800 520 720 520 C 640 520 560 516 520 510 Z M704 392 L784 392 L784 520 L704 520 Z M408 392 L488 392 L488 520 L408 520 Z"/>
+  </g>
+  <g id="region-c10" data-cell-id="c10" data-color-id="9" data-color-name="Spring Green" data-color-hex="#9dd989">
+    <title>Region c10 – Color #9 (Spring Green)</title>
+    <path fill-rule="evenodd" d="M0 472 C 80 494 160 512 240 522 C 300 530 360 532 420 528 L420 560 C 340 576 260 584 180 580 C 120 578 60 568 0 552 Z M96 472 L176 472 L176 580 L96 580 Z"/>
+  </g>
+  <g id="region-c11" data-cell-id="c11" data-color-id="9" data-color-name="Spring Green" data-color-hex="#9dd989">
+    <title>Region c11 – Color #9 (Spring Green)</title>
+    <path fill-rule="evenodd" d="M540 528 C 620 520 700 504 780 486 C 860 468 920 450 960 440 L960 560 C 880 576 800 588 720 588 C 640 588 580 578 540 568 Z M704 472 L784 472 L784 580 L704 580 Z"/>
+  </g>
+  <g id="region-c12" data-cell-id="c12" data-color-id="2" data-color-name="Forest Floor" data-color-hex="#5f432c">
+    <title>Region c12 – Color #2 (Forest Floor)</title>
+    <path fill-rule="evenodd" d="M0 552 C 120 580 240 596 360 598 C 440 600 520 596 600 588 C 720 576 840 556 960 528 L960 600 H0 Z M288 512 C 340 488 400 470 460 466 C 520 462 580 470 630 488 C 680 506 716 530 732 558 C 700 584 656 600 600 608 C 520 620 440 618 360 604 C 300 594 240 574 200 546 Z M408 468 L488 468 L488 600 L408 600 Z"/>
+  </g>
+  <g id="region-c13" data-cell-id="c13" data-color-id="8" data-color-name="Sunlight" data-color-hex="#f4cf74">
+    <title>Region c13 – Color #8 (Sunlight)</title>
+    <path fill-rule="evenodd" d="M288 512 C 336 488 392 470 448 466 C 512 462 576 472 624 492 C 664 510 692 536 706 568 C 684 600 648 622 600 632 C 540 644 472 640 412 624 C 356 608 312 582 292 550 C 280 532 280 522 288 512 Z M408 468 L488 468 L488 600 L408 600 Z"/>
+  </g>
+  <g id="region-c14" data-cell-id="c14" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c14 – Color #3 (Leaf Light)</title>
+    <path fill-rule="evenodd" d="M220 420 C 260 432 300 446 340 460 C 360 468 380 478 400 490 L400 540 C 360 532 320 520 280 506 C 220 486 160 464 100 440 Z M288 420 L360 420 L360 520 L288 520 Z"/>
+  </g>
+  <g id="region-c15" data-cell-id="c15" data-color-id="7" data-color-name="Bark Light" data-color-hex="#c88951">
+    <title>Region c15 – Color #7 (Bark Light)</title>
+    <path d="M96 200 C 100 280 104 360 106 440 C 108 520 110 600 112 600 L144 600 C 148 520 150 440 150 360 C 150 280 148 220 144 200 Z"/>
+  </g>
+  <g id="region-c16" data-cell-id="c16" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c16 – Color #5 (Bark Dark)</title>
+    <path d="M144 200 C 150 280 154 360 156 440 C 158 520 158 600 158 600 L176 600 L176 200 Z"/>
+  </g>
+  <g id="region-c17" data-cell-id="c17" data-color-id="6" data-color-name="Bark Mid" data-color-hex="#7c5133">
+    <title>Region c17 – Color #6 (Bark Mid)</title>
+    <path d="M408 200 C 410 300 414 400 418 500 C 420 560 422 600 422 600 L452 600 C 456 520 458 440 460 360 C 460 280 458 220 454 200 Z"/>
+  </g>
+  <g id="region-c18" data-cell-id="c18" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c18 – Color #5 (Bark Dark)</title>
+    <path d="M452 200 C 456 280 458 360 460 440 C 462 520 462 600 462 600 L488 600 L488 200 Z"/>
+  </g>
+  <g id="region-c19" data-cell-id="c19" data-color-id="7" data-color-name="Bark Light" data-color-hex="#c88951">
+    <title>Region c19 – Color #7 (Bark Light)</title>
+    <path d="M704 200 C 708 288 712 376 716 464 C 718 528 720 600 722 600 L752 600 C 756 520 758 440 758 360 C 758 280 756 220 752 200 Z"/>
+  </g>
+  <g id="region-c20" data-cell-id="c20" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c20 – Color #5 (Bark Dark)</title>
+    <path d="M752 200 C 756 280 758 360 760 440 C 762 520 762 600 762 600 L784 600 L784 200 Z"/>
+  </g>
+</svg>

--- a/art/starter-fallbacks.js
+++ b/art/starter-fallbacks.js
@@ -1,0 +1,241 @@
+(function () {
+  const fallbackSvgs = {
+    "starter-capybara-lagoon": String.raw`<!-- Capybara Lagoon Sunrise - Segmented SVG -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Capybara Lagoon Sunrise</title>
+  <desc id="desc">Layered sunrise bands over a lagoon with a stylized capybara on the shore.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="1" data-color-name="Sunrise Sky" data-color-hex="#f6bf60">
+    <title>Region c1 – Color #1 (Sunrise Sky)</title>
+    <path d="M0 0 L960 0 L960 80 C 820 70 680 68 540 72 C 380 78 220 86 0 80 Z"/>
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="1" data-color-name="Sunrise Sky" data-color-hex="#f6bf60">
+    <title>Region c2 – Color #1 (Sunrise Sky)</title>
+    <path d="M0 80 C 200 90 360 86 540 80 C 720 74 860 76 960 80 L960 148 C 820 142 680 148 520 156 C 360 166 200 164 0 148 Z"/>
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="2" data-color-name="Amber Drift" data-color-hex="#f4994c">
+    <title>Region c3 – Color #2 (Amber Drift)</title>
+    <path d="M0 148 C 160 156 320 160 520 152 C 500 176 480 198 440 212 C 320 220 160 218 0 216 Z"/>
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="2" data-color-name="Amber Drift" data-color-hex="#f4994c">
+    <title>Region c4 – Color #2 (Amber Drift)</title>
+    <path d="M520 152 C 700 150 840 146 960 148 C 940 176 900 198 860 210 C 740 220 640 220 520 214 C 520 194 520 172 520 152 Z"/>
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c5 – Color #3 (Violet Ridge)</title>
+    <path d="M0 216 C 120 228 220 232 320 230 C 300 248 260 268 210 278 C 150 286 80 284 0 280 Z"/>
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c6 – Color #3 (Violet Ridge)</title>
+    <path d="M320 230 C 440 236 520 234 640 226 C 630 250 600 268 560 276 C 480 286 400 284 320 278 C 320 258 320 244 320 230 Z"/>
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="3" data-color-name="Violet Ridge" data-color-hex="#9a6bb3">
+    <title>Region c7 – Color #3 (Violet Ridge)</title>
+    <path d="M640 226 C 760 224 860 220 960 220 C 940 240 900 260 860 272 C 780 286 700 284 640 278 C 640 256 640 240 640 226 Z"/>
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c8 – Color #4 (Forest Ridge)</title>
+    <path d="M0 280 C 100 292 200 300 320 292 C 300 312 260 328 210 336 C 150 344 80 344 0 340 Z"/>
+  </g>
+  <g id="region-c09" data-cell-id="c9" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c9 – Color #4 (Forest Ridge)</title>
+    <path d="M320 292 C 440 298 540 300 640 298 C 620 318 580 332 540 340 C 460 348 380 346 320 340 C 320 320 320 306 320 292 Z"/>
+  </g>
+  <g id="region-c10" data-cell-id="c10" data-color-id="4" data-color-name="Forest Ridge" data-color-hex="#5d7a76">
+    <title>Region c10 – Color #4 (Forest Ridge)</title>
+    <path d="M640 298 C 760 300 860 300 960 300 C 940 320 900 332 860 340 C 780 348 700 348 640 340 C 640 320 640 308 640 298 Z"/>
+  </g>
+  <g id="region-c11" data-cell-id="c11" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c11 – Color #5 (Lagoon Light)</title>
+    <path d="M0 340 C 120 344 220 346 320 344 C 300 350 300 352 320 352 C 200 356 120 354 0 352 C 0 348 0 344 0 340 Z"/>
+  </g>
+  <g id="region-c12" data-cell-id="c12" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c12 – Color #5 (Lagoon Light)</title>
+    <path d="M320 344 C 440 346 540 344 640 342 C 640 346 640 350 640 352 C 520 356 420 356 320 352 C 320 348 320 346 320 344 Z"/>
+  </g>
+  <g id="region-c13" data-cell-id="c13" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c13 – Color #5 (Lagoon Light)</title>
+    <path d="M640 342 C 760 340 860 338 960 340 C 960 344 960 348 960 352 C 840 354 740 354 640 352 C 640 348 640 344 640 342 Z"/>
+  </g>
+  <g id="region-c14" data-cell-id="c14" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c14 – Color #5 (Lagoon Light)</title>
+    <path d="M0 352 C 120 356 220 356 320 352 C 310 364 310 372 320 376 C 200 382 120 380 0 376 C 0 364 0 358 0 352 Z"/>
+  </g>
+  <g id="region-c15" data-cell-id="c15" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c15 – Color #5 (Lagoon Light)</title>
+    <path d="M320 352 C 440 354 540 352 640 352 C 650 362 650 370 640 376 C 520 382 420 382 320 376 C 320 366 320 360 320 352 Z"/>
+  </g>
+  <g id="region-c16" data-cell-id="c16" data-color-id="5" data-color-name="Lagoon Light" data-color-hex="#76c7d6">
+    <title>Region c16 – Color #5 (Lagoon Light)</title>
+    <path d="M640 352 C 760 352 860 350 960 352 C 960 362 960 372 960 376 C 840 380 740 380 640 376 C 640 366 640 358 640 352 Z"/>
+  </g>
+  <g id="region-c17" data-cell-id="c17" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c17 – Color #6 (Lagoon Depth)</title>
+    <path d="M0 376 C 160 382 320 388 480 384 C 480 394 480 400 480 404 C 320 408 160 404 0 404 C 0 392 0 384 0 376 Z"/>
+  </g>
+  <g id="region-c18" data-cell-id="c18" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c18 – Color #6 (Lagoon Depth)</title>
+    <path d="M480 376 C 640 382 800 380 960 376 L960 404 C 800 410 640 412 480 404 C 480 394 480 386 480 376 Z"/>
+  </g>
+  <g id="region-c19" data-cell-id="c19" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c19 – Color #6 (Lagoon Depth)</title>
+    <path d="M0 404 C 160 410 320 416 480 412 C 480 428 480 440 480 448 C 320 456 160 452 0 448 C 0 430 0 416 0 404 Z"/>
+  </g>
+  <g id="region-c20" data-cell-id="c20" data-color-id="6" data-color-name="Lagoon Depth" data-color-hex="#1c6f8c">
+    <title>Region c20 – Color #6 (Lagoon Depth)</title>
+    <path d="M480 412 C 640 416 800 410 960 404 L960 448 C 820 456 680 460 520 456 C 500 454 490 448 480 448 C 480 432 480 420 480 412 Z"/>
+  </g>
+  <g id="region-c21" data-cell-id="c21" data-color-id="7" data-color-name="Shore Left" data-color-hex="#4f7d5c">
+    <title>Region c21 – Color #7 (Shore Left)</title>
+    <path d="M0 448 C 120 454 220 458 300 462 C 280 500 220 540 140 566 C 80 584 30 592 0 592 C 0 544 0 496 0 448 Z"/>
+  </g>
+  <g id="region-c22" data-cell-id="c22" data-color-id="7" data-color-name="Shore Left" data-color-hex="#4f7d5c">
+    <title>Region c22 – Color #7 (Shore Left)</title>
+    <path d="M300 462 C 360 468 420 472 520 456 C 510 486 490 514 460 540 C 420 568 360 580 300 572 C 280 540 290 500 300 462 Z"/>
+  </g>
+  <g id="region-c23" data-cell-id="c23" data-color-id="8" data-color-name="Shore Middle" data-color-hex="#6b9358">
+    <title>Region c23 – Color #8 (Shore Middle)</title>
+    <path d="M520 456 C 640 462 720 464 780 460 C 788 474 792 498 796 528 C 786 580 768 584 752 588 C 700 600 656 598 604 588 C 566 580 534 564 518 546 C 506 532 506 520 520 510 C 508 496 512 476 520 456 Z"/>
+  </g>
+  <g id="region-c24" data-cell-id="c24" data-color-id="9" data-color-name="Capy Body" data-color-hex="#7d5735">
+    <title>Region c24 – Color #9 (Capy Body)</title>
+    <path d="M520 510 C 548 470 612 440 692 434 C 744 430 768 438 780 456 C 790 474 794 498 796 528 C 798 556 786 580 752 588 C 708 600 656 598 604 588 C 566 580 534 564 518 546 C 508 532 506 518 520 510 Z"/>
+  </g>
+  <g id="region-c25" data-cell-id="c25" data-color-id="10" data-color-name="Capy Head" data-color-hex="#5e3b24">
+    <title>Region c25 – Color #10 (Capy Head)</title>
+    <path d="M780 456 C 804 438 838 438 866 460 C 894 482 904 520 892 556 C 878 594 846 608 810 600 C 800 598 796 590 796 528 C 794 500 788 474 780 456 Z"/>
+  </g>
+  <g id="region-c26" data-cell-id="c26" data-color-id="11" data-color-name="Shore Right" data-color-hex="#3f5b3b">
+    <title>Region c26 – Color #11 (Shore Right)</title>
+    <path d="M780 460 C 840 456 900 454 960 452 L960 600 C 910 600 870 598 810 600 C 846 608 878 594 892 556 C 884 520 860 488 780 460 Z"/>
+  </g>
+</svg>
+`,
+    "starter-twilight-marsh": String.raw`<!-- Twilight Marsh Study - Segmented SVG -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Twilight Marsh Study</title>
+  <desc id="desc">Bands of twilight sky over a reflective marsh with silhouetted capybaras along the shore.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="1" data-color-name="Evening Sky" data-color-hex="#f7c59f">
+    <path d="M0 0 L960 0 L960 160 C 640 150 320 150 0 160 Z" />
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="2" data-color-name="Glow Band" data-color-hex="#f27d72">
+    <path d="M0 160 C 160 180 320 180 480 185 C 640 190 800 180 960 170 L960 230 C 640 240 320 240 0 230 Z" />
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="3" data-color-name="Distant Ridge" data-color-hex="#8c5fa6">
+    <path d="M0 230 C 200 260 400 250 600 270 C 800 290 880 270 960 280 L960 340 L0 340 Z" />
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="4" data-color-name="Low Ridge" data-color-hex="#546d7a">
+    <path d="M0 340 C 200 360 400 360 600 355 C 800 350 880 350 960 355 L960 420 L0 420 Z" />
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="5" data-color-name="River Mirror" data-color-hex="#4f9fc6">
+    <path d="M0 420 C 220 440 440 450 660 440 C 800 434 880 430 960 432 L960 490 L0 490 Z" />
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="6" data-color-name="River Depth" data-color-hex="#1f6b8f">
+    <path d="M0 490 C 200 510 400 520 600 515 C 800 510 880 508 960 510 L960 555 L0 555 Z" />
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="7" data-color-name="Shore Glow" data-color-hex="#5d8f63">
+    <path d="M0 555 C 180 570 360 580 540 575 L540 600 L0 600 Z" />
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="8" data-color-name="Shore Shadow" data-color-hex="#2f4c45">
+    <path d="M540 575 C 700 570 840 565 960 570 L960 600 L540 600 Z" />
+  </g>
+</svg>
+`,
+    "starter-lush-forest": String.raw`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" role="img" aria-labelledby="title desc">
+  <title id="title">Lush Green Forest Walk</title>
+  <desc id="desc">Layered forest scene with tall trunks framing a winding path through a sunlit clearing.</desc>
+  <g id="region-c01" data-cell-id="c1" data-color-id="11" data-color-name="Sky Mist" data-color-hex="#d7e9f8">
+    <title>Region c1 – Color #11 (Sky Mist)</title>
+    <path d="M0 0 H960 V150 Q 870 120 760 132 Q 660 144 560 134 Q 460 124 360 136 Q 240 148 140 134 Q 60 122 0 140 Z"/>
+  </g>
+  <g id="region-c02" data-cell-id="c2" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c2 – Color #3 (Leaf Light)</title>
+    <path d="M0 140 Q 90 110 200 126 Q 280 138 320 160 L320 220 Q 220 210 150 208 Q 70 206 0 200 Z"/>
+  </g>
+  <g id="region-c03" data-cell-id="c3" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c3 – Color #3 (Leaf Light)</title>
+    <path d="M320 160 Q 420 136 520 136 Q 620 136 660 158 L660 220 Q 560 210 470 212 Q 380 214 320 220 Z"/>
+  </g>
+  <g id="region-c04" data-cell-id="c4" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c4 – Color #3 (Leaf Light)</title>
+    <path d="M660 158 Q 760 136 850 126 Q 930 118 960 140 L960 220 Q 860 210 780 208 Q 700 206 660 220 Z"/>
+  </g>
+  <g id="region-c05" data-cell-id="c5" data-color-id="1" data-color-name="Forest Deep" data-color-hex="#1f3f2c">
+    <title>Region c5 – Color #1 (Forest Deep)</title>
+    <path fill-rule="evenodd" d="M0 200 C 160 220 320 230 480 232 C 640 234 800 226 960 214 L960 320 C 820 338 680 346 540 342 C 380 338 220 328 0 308 Z M96 200 L176 200 L176 360 L96 360 Z M408 200 L488 200 L488 360 L408 360 Z M704 200 L784 200 L784 360 L704 360 Z"/>
+  </g>
+  <g id="region-c06" data-cell-id="c6" data-color-id="4" data-color-name="Leaf Mid" data-color-hex="#7fca63">
+    <title>Region c6 – Color #4 (Leaf Mid)</title>
+    <path fill-rule="evenodd" d="M0 308 C 140 326 280 336 420 340 C 460 342 480 340 520 334 L520 400 C 420 410 320 420 220 418 C 140 416 60 408 0 400 Z M96 300 L176 300 L176 420 L96 420 Z M408 300 L488 300 L488 420 L408 420 Z"/>
+  </g>
+  <g id="region-c07" data-cell-id="c7" data-color-id="4" data-color-name="Leaf Mid" data-color-hex="#7fca63">
+    <title>Region c7 – Color #4 (Leaf Mid)</title>
+    <path fill-rule="evenodd" d="M520 334 C 640 326 760 318 880 314 C 920 312 940 314 960 316 L960 400 C 840 412 720 420 600 416 C 540 414 500 410 460 404 L460 340 Z M704 300 L784 300 L784 420 L704 420 Z M408 300 L488 300 L488 420 L408 420 Z"/>
+  </g>
+  <g id="region-c08" data-cell-id="c8" data-color-id="10" data-color-name="Canopy Shadow" data-color-hex="#2f4d30">
+    <title>Region c8 – Color #10 (Canopy Shadow)</title>
+    <path fill-rule="evenodd" d="M0 400 C 120 416 240 430 360 438 C 420 442 460 446 520 452 L520 500 C 420 510 320 516 220 508 C 140 502 60 488 0 472 Z M96 392 L176 392 L176 520 L96 520 Z M408 392 L488 392 L488 520 L408 520 Z"/>
+  </g>
+  <g id="region-c09" data-cell-id="c9" data-color-id="10" data-color-name="Canopy Shadow" data-color-hex="#2f4d30">
+    <title>Region c9 – Color #10 (Canopy Shadow)</title>
+    <path fill-rule="evenodd" d="M520 452 C 600 446 680 438 760 430 C 860 420 940 412 960 410 L960 500 C 880 512 800 520 720 520 C 640 520 560 516 520 510 Z M704 392 L784 392 L784 520 L704 520 Z M408 392 L488 392 L488 520 L408 520 Z"/>
+  </g>
+  <g id="region-c10" data-cell-id="c10" data-color-id="9" data-color-name="Spring Green" data-color-hex="#9dd989">
+    <title>Region c10 – Color #9 (Spring Green)</title>
+    <path fill-rule="evenodd" d="M0 472 C 80 494 160 512 240 522 C 300 530 360 532 420 528 L420 560 C 340 576 260 584 180 580 C 120 578 60 568 0 552 Z M96 472 L176 472 L176 580 L96 580 Z"/>
+  </g>
+  <g id="region-c11" data-cell-id="c11" data-color-id="9" data-color-name="Spring Green" data-color-hex="#9dd989">
+    <title>Region c11 – Color #9 (Spring Green)</title>
+    <path fill-rule="evenodd" d="M540 528 C 620 520 700 504 780 486 C 860 468 920 450 960 440 L960 560 C 880 576 800 588 720 588 C 640 588 580 578 540 568 Z M704 472 L784 472 L784 580 L704 580 Z"/>
+  </g>
+  <g id="region-c12" data-cell-id="c12" data-color-id="2" data-color-name="Forest Floor" data-color-hex="#5f432c">
+    <title>Region c12 – Color #2 (Forest Floor)</title>
+    <path fill-rule="evenodd" d="M0 552 C 120 580 240 596 360 598 C 440 600 520 596 600 588 C 720 576 840 556 960 528 L960 600 H0 Z M288 512 C 340 488 400 470 460 466 C 520 462 580 470 630 488 C 680 506 716 530 732 558 C 700 584 656 600 600 608 C 520 620 440 618 360 604 C 300 594 240 574 200 546 Z M408 468 L488 468 L488 600 L408 600 Z"/>
+  </g>
+  <g id="region-c13" data-cell-id="c13" data-color-id="8" data-color-name="Sunlight" data-color-hex="#f4cf74">
+    <title>Region c13 – Color #8 (Sunlight)</title>
+    <path fill-rule="evenodd" d="M288 512 C 336 488 392 470 448 466 C 512 462 576 472 624 492 C 664 510 692 536 706 568 C 684 600 648 622 600 632 C 540 644 472 640 412 624 C 356 608 312 582 292 550 C 280 532 280 522 288 512 Z M408 468 L488 468 L488 600 L408 600 Z"/>
+  </g>
+  <g id="region-c14" data-cell-id="c14" data-color-id="3" data-color-name="Leaf Light" data-color-hex="#b6e480">
+    <title>Region c14 – Color #3 (Leaf Light)</title>
+    <path fill-rule="evenodd" d="M220 420 C 260 432 300 446 340 460 C 360 468 380 478 400 490 L400 540 C 360 532 320 520 280 506 C 220 486 160 464 100 440 Z M288 420 L360 420 L360 520 L288 520 Z"/>
+  </g>
+  <g id="region-c15" data-cell-id="c15" data-color-id="7" data-color-name="Bark Light" data-color-hex="#c88951">
+    <title>Region c15 – Color #7 (Bark Light)</title>
+    <path d="M96 200 C 100 280 104 360 106 440 C 108 520 110 600 112 600 L144 600 C 148 520 150 440 150 360 C 150 280 148 220 144 200 Z"/>
+  </g>
+  <g id="region-c16" data-cell-id="c16" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c16 – Color #5 (Bark Dark)</title>
+    <path d="M144 200 C 150 280 154 360 156 440 C 158 520 158 600 158 600 L176 600 L176 200 Z"/>
+  </g>
+  <g id="region-c17" data-cell-id="c17" data-color-id="6" data-color-name="Bark Mid" data-color-hex="#7c5133">
+    <title>Region c17 – Color #6 (Bark Mid)</title>
+    <path d="M408 200 C 410 300 414 400 418 500 C 420 560 422 600 422 600 L452 600 C 456 520 458 440 460 360 C 460 280 458 220 454 200 Z"/>
+  </g>
+  <g id="region-c18" data-cell-id="c18" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c18 – Color #5 (Bark Dark)</title>
+    <path d="M452 200 C 456 280 458 360 460 440 C 462 520 462 600 462 600 L488 600 L488 200 Z"/>
+  </g>
+  <g id="region-c19" data-cell-id="c19" data-color-id="7" data-color-name="Bark Light" data-color-hex="#c88951">
+    <title>Region c19 – Color #7 (Bark Light)</title>
+    <path d="M704 200 C 708 288 712 376 716 464 C 718 528 720 600 722 600 L752 600 C 756 520 758 440 758 360 C 758 280 756 220 752 200 Z"/>
+  </g>
+  <g id="region-c20" data-cell-id="c20" data-color-id="5" data-color-name="Bark Dark" data-color-hex="#4c2f1f">
+    <title>Region c20 – Color #5 (Bark Dark)</title>
+    <path d="M752 200 C 756 280 758 360 760 440 C 762 520 762 600 762 600 L784 600 L784 200 Z"/>
+  </g>
+</svg>
+`
+  };
+  const globalStore = (window.__starterSvgFallbacks = window.__starterSvgFallbacks || {});
+  Object.assign(globalStore, fallbackSvgs);
+  const applyMarker = () => {
+    if (typeof document !== 'undefined' && document.body) {
+      document.body.setAttribute('data-inline-fallbacks', Object.keys(globalStore).join(','));
+    }
+  };
+  if (typeof document !== 'undefined' && document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyMarker, { once: true });
+  } else {
+    applyMarker();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     <script src="./vendor/react.development.js"></script>
     <script src="./vendor/react-dom.development.js"></script>
     <script src="./vendor/babel.min.js"></script>
+    <script src="./art/starter-fallbacks.js"></script>
     <script type="text/babel">
 const { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } = React;
 
@@ -96,64 +97,295 @@ let measureCanvasCtx = null;
  * @property {number} lastSaved
  */
 
-// ---------- Sample Artwork ----------
-const DEMO_ART = {
-  id: "demo-capybara-forest",
-  title: "Capybara Forest Retreat",
-  width: 960,
-  height: 600,
-  palette: [
-    { id: 1, name: "Sky Mist", rgba: "#86c5ff" },
-    { id: 2, name: "Sky Veil", rgba: "#e6f0ff" },
-    { id: 3, name: "Dawn Glow", rgba: "#fef6e4" },
-    { id: 4, name: "Distant Hills", rgba: "#b7d1a7" },
-    { id: 5, name: "Pine Canopy", rgba: "#2f7a33" },
-    { id: 6, name: "Pine Shadow", rgba: "#255f27" },
-    { id: 7, name: "Pond Light", rgba: "#7fd5ef" },
-    { id: 8, name: "Meadow Moss", rgba: "#3b7b46" },
-    { id: 9, name: "Capybara Fur", rgba: "#8e5b3a" },
-    { id: 10, name: "Capybara Shade", rgba: "#5a3d2a" },
-    { id: 11, name: "Forest Accent", rgba: "#2c6e49" },
-  ],
-  cells: [
-    { id: "c1", colorId: 1, d: "M0 0 L960 0 L960 140 C 860 150 760 150 660 140 C 560 130 480 130 400 140 C 280 155 160 150 0 130 Z" },
-    { id: "c2", colorId: 3, d: "M0 130 C 160 150 320 160 480 160 L480 210 C 320 205 160 200 0 190 Z" },
-    { id: "c3", colorId: 2, d: "M480 160 C 640 170 800 160 960 140 L960 210 C 800 215 640 215 480 210 Z" },
-    { id: "c4", colorId: 4, d: "M0 190 C 120 210 240 220 360 220 C 400 220 420 218 420 218 L420 260 L0 260 Z" },
-    { id: "c5", colorId: 4, d: "M420 218 C 560 210 700 210 840 205 C 900 202 940 200 960 205 L960 260 L420 260 Z" },
-    { id: "c6", colorId: 5, d: "M0 260 C 100 300 220 320 300 330 C 220 340 140 350 40 340 C 20 330 0 300 0 260 Z" },
-    { id: "c7", colorId: 6, d: "M300 330 C 380 300 500 290 620 300 C 680 310 740 330 780 360 L780 360 L300 360 Z" },
-    { id: "c8", colorId: 5, d: "M780 360 C 820 320 880 300 960 290 L960 360 L780 360 Z" },
-    { id: "c9", colorId: 6, d: "M0 360 C 120 380 240 390 360 390 C 480 390 600 370 720 360 C 820 350 900 350 960 360 L960 420 C 860 430 760 430 660 420 C 560 410 460 410 360 420 C 240 430 120 420 0 400 Z" },
-    { id: "c10", colorId: 2, d: "M0 420 C 160 440 320 450 480 445 C 640 440 800 430 960 420 L960 460 C 800 480 640 490 480 485 C 320 480 160 470 0 450 Z" },
-    { id: "c11", colorId: 7, d: "M0 460 C 160 480 320 495 480 490 C 640 485 800 470 960 460 L960 500 L0 500 Z" },
-    { id: "c12", colorId: 8, d: "M0 500 L170 508 L170 560 L0 560 Z" },
-    { id: "c13", colorId: 8, d: "M240 508 L320 515 L320 560 L240 560 Z" },
-    { id: "c14", colorId: 8, d: "M320 515 L360 518 L360 560 L320 560 Z" },
-    { id: "c15", colorId: 8, d: "M680 515 L720 518 L720 560 L680 560 Z" },
-    { id: "c16", colorId: 3, d: "M168 500 L240 504 L240 540 C 224 548 204 552 176 554 L168 554 Z" },
-    { id: "c17", colorId: 11, d: "M160 540 C 188 518 216 518 240 540 L240 560 L160 560 Z" },
-    { id: "c18", colorId: 9, d: "M360 540 L360 508 C 380 472 430 450 500 444 C 580 438 650 456 680 496 L680 540 Z" },
-    { id: "c19", colorId: 10, d: "M360 540 L680 540 L680 560 C 620 576 540 582 460 576 C 400 572 372 562 360 552 Z" },
-    { id: "c20", colorId: 8, d: "M720 518 L736 516 L736 560 L720 560 Z" },
-    { id: "c21", colorId: 3, d: "M736 500 L792 504 L792 540 C 780 546 766 550 744 552 L736 552 Z" },
-    { id: "c22", colorId: 11, d: "M724 540 C 752 520 788 520 820 540 L820 560 L724 560 Z" },
-    { id: "c23", colorId: 8, d: "M792 504 L820 502 L820 540 L792 540 Z" },
-    { id: "c24", colorId: 8, d: "M820 502 L880 500 L880 560 L820 560 Z" },
-    { id: "c25", colorId: 8, d: "M880 500 L960 500 L960 560 L880 560 Z" },
-    { id: "c26", colorId: 8, d: "M0 560 C 200 580 400 590 600 585 C 760 580 880 570 960 575 L960 600 L0 600 Z" },
-  ].map((c) => ({ ...c, area: estimatePathArea(c.d) })),
-};
-function cloneArtwork(art) {
-  return {
-    ...art,
-    palette: (art.palette ?? []).map((p) => ({ ...p })),
-    cells: (art.cells ?? []).map((c) => ({ ...c })),
-  };
+const STARTER_SOURCES = [
+  {
+    id: "starter-capybara-lagoon",
+    url: "./art/capybara-lagoon.svg",
+    filename: "capybara-lagoon.svg",
+    type: "image/svg+xml",
+  },
+  {
+    id: "starter-twilight-marsh",
+    url: "./art/capybara-twilight.svg",
+    filename: "capybara-twilight.svg",
+    type: "image/svg+xml",
+  },
+  {
+    id: "starter-lush-forest",
+    url: "./art/lush-green-forest.svg",
+    filename: "lush-green-forest.svg",
+    type: "image/svg+xml",
+  },
+];
+
+function getLegacyStarterArtworks() {
+  return [];
 }
 
-function getStarterArtworks() {
-  return [cloneArtwork(DEMO_ART)];
+function loadSvgViaObject(url, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    if (!document?.body) {
+      reject(new Error('The document body is unavailable.'));
+      return;
+    }
+
+    const objectEl = document.createElement('object');
+    objectEl.type = 'image/svg+xml';
+    objectEl.setAttribute('aria-hidden', 'true');
+    objectEl.style.position = 'absolute';
+    objectEl.style.width = '0';
+    objectEl.style.height = '0';
+    objectEl.style.pointerEvents = 'none';
+    objectEl.style.opacity = '0';
+
+    const cleanup = () => {
+      objectEl.removeEventListener('load', handleLoad);
+      objectEl.removeEventListener('error', handleError);
+      if (signal) {
+        signal.removeEventListener('abort', handleAbort);
+      }
+      if (objectEl.parentNode) {
+        objectEl.parentNode.removeChild(objectEl);
+      }
+    };
+
+    const handleAbort = () => {
+      cleanup();
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+    };
+
+    const handleLoad = () => {
+      try {
+        const doc = objectEl.contentDocument;
+        if (!doc) {
+          throw new Error('Unable to access the SVG document.');
+        }
+        const svgEl = doc.documentElement;
+        if (!svgEl) {
+          throw new Error('The SVG content is empty.');
+        }
+        resolve(svgEl.outerHTML);
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error('Unable to read the SVG content.'));
+      } finally {
+        cleanup();
+      }
+    };
+
+    const handleError = () => {
+      cleanup();
+      reject(new Error('Unable to load the SVG via <object>.'));
+    };
+
+    objectEl.addEventListener('load', handleLoad);
+    objectEl.addEventListener('error', handleError);
+    if (signal) {
+      signal.addEventListener('abort', handleAbort, { once: true });
+    }
+    document.body.appendChild(objectEl);
+    try {
+      const resolved = new URL(url, window.location.href);
+      objectEl.data = resolved.href;
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new Error('Invalid SVG URL.'));
+    }
+  });
+}
+
+function loadSvgViaXhr(url, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    let aborted = false;
+    const xhr = new XMLHttpRequest();
+    const cleanup = () => {
+      xhr.onerror = null;
+      xhr.onreadystatechange = null;
+      if (signal) {
+        signal.removeEventListener('abort', handleAbort);
+      }
+    };
+    const handleAbort = () => {
+      aborted = true;
+      xhr.abort();
+      cleanup();
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+    };
+
+    xhr.onerror = () => {
+      cleanup();
+      reject(new Error('Unable to load the SVG via XMLHttpRequest.'));
+    };
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return;
+      cleanup();
+      if (aborted) return;
+      const status = xhr.status;
+      if (status === 0 || (status >= 200 && status < 300)) {
+        resolve(xhr.responseText);
+      } else {
+        reject(new Error(`XMLHttpRequest failed with status ${status}.`));
+      }
+    };
+
+    try {
+      const resolved = new URL(url, window.location.href);
+      xhr.open('GET', resolved.href, true);
+      xhr.overrideMimeType('image/svg+xml');
+      if (signal) {
+        signal.addEventListener('abort', handleAbort, { once: true });
+      }
+      xhr.send();
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new Error('Unable to resolve the SVG URL.'));
+    }
+  });
+}
+
+async function loadStarterArtworks(signal) {
+  const results = [];
+  const seenIds = new Set();
+  const errors = [];
+
+  const inlineFallbacks =
+    typeof window !== "undefined" ? window.__starterSvgFallbacks ?? null : null;
+  const isFileProtocol =
+    typeof window !== "undefined" && window.location?.protocol === "file:";
+
+  for (const source of STARTER_SOURCES) {
+    let candidate = null;
+
+    const failureReasons = [];
+    const meta = {
+      filename: source.filename ?? source.url?.split("/").pop(),
+      type: source.type ?? "image/svg+xml",
+      source: "starter",
+    };
+    const parseSource = (raw) => {
+      const parsed = parseArtworkPayload(raw, meta);
+      if (parsed.ok && parsed.artwork) {
+        return cloneArtwork(parsed.artwork);
+      }
+      throw new Error(parsed.error ?? "Unable to convert the artwork payload.");
+    };
+
+    if (!candidate && source.url) {
+      const loaders = [];
+      const addLoader = (label, fn) => loaders.push({ label, fn });
+
+      if (isFileProtocol) {
+        addLoader("<object>", () => loadSvgViaObject(source.url, signal));
+        addLoader("XMLHttpRequest", () => loadSvgViaXhr(source.url, signal));
+        addLoader("fetch", async () => {
+          const response = await fetch(source.url, { signal });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          return response.text();
+        });
+      } else {
+        addLoader("fetch", async () => {
+          const response = await fetch(source.url, { signal });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          return response.text();
+        });
+        addLoader("XMLHttpRequest", () => loadSvgViaXhr(source.url, signal));
+        addLoader("<object>", () => loadSvgViaObject(source.url, signal));
+      }
+
+      for (const loader of loaders) {
+        if (candidate) break;
+        try {
+          const raw = await loader.fn();
+          candidate = parseSource(raw);
+          if (candidate) {
+            console.info(
+              `Loaded starter artwork from ${source.url} via ${loader.label}.`
+            );
+          }
+        } catch (err) {
+          const normalized = err instanceof Error ? err : new Error(String(err));
+          failureReasons.push(normalized);
+          console.warn(
+            `Unable to load starter artwork from ${source.url} via ${loader.label}:`,
+            normalized
+          );
+        }
+      }
+    }
+
+    if (!candidate && inlineFallbacks?.[source.id]) {
+      try {
+        candidate = parseSource(inlineFallbacks[source.id]);
+        if (candidate) {
+          console.info(
+            `Loaded starter artwork from ${source.url || source.id} via inline fallback.`
+          );
+        }
+      } catch (err) {
+        const normalized = err instanceof Error ? err : new Error(String(err));
+        failureReasons.push(normalized);
+        console.warn(
+          `Unable to parse inline fallback for ${source.url || source.id}:`,
+          normalized
+        );
+      }
+    }
+
+    if (!candidate) {
+      if (failureReasons.length) {
+        errors.push(failureReasons[0]);
+      } else {
+        errors.push(
+          new Error(`Unable to load starter artwork from ${source.url || source.id || 'starter art'}.`)
+        );
+      }
+      continue;
+    }
+
+    let id = (candidate.id ?? "").toString().trim();
+    if (!id) {
+      id = source.id || `starter-${Math.random().toString(36).slice(2, 8)}`;
+      candidate = { ...candidate, id };
+    }
+
+    if (seenIds.has(id)) {
+      let suffix = 2;
+      let uniqueId = `${id}-${suffix}`;
+      while (seenIds.has(uniqueId)) {
+        uniqueId = `${id}-${++suffix}`;
+      }
+      candidate = { ...candidate, id: uniqueId };
+      seenIds.add(uniqueId);
+    } else {
+      seenIds.add(id);
+    }
+
+    if (!candidate.title && source.title) {
+      candidate = { ...candidate, title: source.title };
+    }
+
+    results.push(candidate);
+  }
+
+  if (!results.length) {
+    return { artworks: getLegacyStarterArtworks(), errors };
+  }
+
+  return { artworks: results, errors };
 }
 
 // Estimate area for heuristics using DOM sampling with a polygon fallback.
@@ -246,6 +478,19 @@ function normalizeArtwork(raw) {
   } catch (err) {
     return null;
   }
+}
+
+function cloneArtwork(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const palette = Array.isArray(raw.palette)
+    ? raw.palette.map((item) => ({ ...item }))
+    : [];
+  const cells = Array.isArray(raw.cells) ? raw.cells.map((cell) => ({ ...cell })) : [];
+  return {
+    ...raw,
+    palette,
+    cells,
+  };
 }
 
 function parseDimension(value) {
@@ -459,17 +704,17 @@ function parseArtworkPayload(raw, meta = {}) {
   }
 }
 
-function loadArtworks() {
+function loadStoredArtworks() {
   try {
     const raw = localStorage.getItem(ARTWORKS_KEY);
-    if (!raw) return getStarterArtworks();
+    if (!raw) return [];
     const parsed = JSON.parse(raw);
     const normalized = (Array.isArray(parsed) ? parsed : [])
       .map((art) => normalizeArtwork(art))
       .filter(Boolean);
-    return normalized.length ? normalized : getStarterArtworks();
+    return normalized;
   } catch (err) {
-    return getStarterArtworks();
+    return [];
   }
 }
 
@@ -578,7 +823,7 @@ function App() {
   const initialArtworksRef = useRef(null);
 
   if (initialArtworksRef.current === null) {
-    initialArtworksRef.current = loadArtworks();
+    initialArtworksRef.current = loadStoredArtworks();
   }
 
   const [artworks, setArtworks] = useState(initialArtworksRef.current);
@@ -603,11 +848,65 @@ function App() {
   const [showOptions, setShowOptions] = useState(false);
   const [showLibrary, setShowLibrary] = useState(false);
   const [libraryRevision, setLibraryRevision] = useState(0);
+  const [starterStatus, setStarterStatus] = useState(
+    initialArtworksRef.current.length
+      ? { state: "ready", error: null }
+      : { state: "idle", error: null }
+  );
 
   const selectArtwork = useCallback((id) => {
     setActiveArtworkIdState(id);
     persistActiveArtworkId(id ?? null);
   }, []);
+
+  useEffect(() => {
+    if (initialArtworksRef.current.length) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function bootstrap() {
+      setStarterStatus({ state: "loading", error: null });
+      try {
+        const { artworks: loaded, errors } = await loadStarterArtworks(controller.signal);
+        if (cancelled) return;
+        initialArtworksRef.current = loaded;
+        setArtworks(loaded);
+        const nextId = loadActiveArtworkId(loaded);
+        if (nextId) {
+          selectArtwork(nextId);
+        }
+        setStarterStatus({
+          state: "ready",
+          error: errors.length
+            ? errors[0] instanceof Error
+              ? errors[0].message
+              : "Unable to load all starter artworks."
+            : null,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        const fallback = getLegacyStarterArtworks();
+        initialArtworksRef.current = fallback;
+        setArtworks(fallback);
+        const nextId = loadActiveArtworkId(fallback);
+        if (nextId) {
+          selectArtwork(nextId);
+        }
+        setStarterStatus({
+          state: "error",
+          error: err instanceof Error ? err.message : "Unable to load starter artworks.",
+        });
+      }
+    }
+
+    bootstrap();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [selectArtwork]);
 
   useEffect(() => {
     persistArtworks(artworks);
@@ -868,8 +1167,16 @@ function App() {
 
   function onWheel(e) {
     if (!art) return;
-    e.preventDefault();
-    const factor = Math.exp(-e.deltaY * 0.0012);
+    if (e.nativeEvent?.cancelable) {
+      e.nativeEvent.preventDefault();
+    } else {
+      e.preventDefault();
+    }
+    const pageSpan =
+      typeof window !== "undefined" && window.innerHeight ? window.innerHeight : 360;
+    const modeFactor = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? pageSpan : 1;
+    const delta = e.deltaY * modeFactor;
+    const factor = Math.exp(-delta * 0.0012);
     const proposed = scale * factor;
     smoothZoomTo(proposed, e.clientX, e.clientY);
   }
@@ -883,6 +1190,14 @@ function App() {
     const target = e.target;
     const cid = target?.dataset?.cellId;
     movedRef.current = 0;
+
+    if (e.pointerType === "mouse" && e.button === 0) {
+      if (e.nativeEvent?.cancelable) {
+        e.nativeEvent.preventDefault();
+      } else {
+        e.preventDefault();
+      }
+    }
 
     if (e.pointerType === "mouse" && (e.button === 2 || e.button === 1 || e.ctrlKey)) {
       e.preventDefault();
@@ -930,6 +1245,14 @@ function App() {
     if (!art) return;
     const svg = svgRef.current;
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (isPanningRef.current && e.pointerType === "mouse") {
+      if (e.nativeEvent?.cancelable) {
+        e.nativeEvent.preventDefault();
+      } else {
+        e.preventDefault();
+      }
+    }
 
     if (pinchRef.current) {
       const { id1, id2, d0, s0, mid0 } = pinchRef.current;
@@ -1134,6 +1457,13 @@ function App() {
           onReset: handleConfigReset,
           onClose: () => setShowOptions(false),
         }),
+      starterStatus.error &&
+        art &&
+        React.createElement(
+          "div",
+          { style: styles.bootstrapBanner, role: "status" },
+          `Starter art could not be loaded automatically (${starterStatus.error}). Import an SVG from the library to continue.`
+        ),
       art
         ? React.createElement(
             "div",
@@ -1145,7 +1475,12 @@ function App() {
                 width: "100%",
                 height: "100%",
                 viewBox: `0 0 ${art.width} ${art.height}`,
-                style: { background: "#0f172a", touchAction: "none" },
+                style: {
+                  background: "#0f172a",
+                  touchAction: "none",
+                  userSelect: "none",
+                  WebkitUserSelect: "none",
+                },
                 onWheel: onWheel,
                 onPointerDown: onPointerDown,
                 onPointerMove: onPointerMove,
@@ -1211,7 +1546,11 @@ function App() {
         : React.createElement(
             "div",
             { style: styles.emptyState },
-            "Import or add an artwork in the library to start painting."
+            starterStatus.state === "loading"
+              ? "Loading starter artwork…"
+              : starterStatus.error
+              ? `Starter art could not be loaded automatically (${starterStatus.error}). Use the library to import a file.`
+              : "Import or add an artwork in the library to start painting."
           ),
       art &&
         enableSmokeHud &&
@@ -1261,28 +1600,6 @@ function App() {
                 "aria-label": "Adjust options",
               },
               "Options"
-            ),
-            React.createElement(
-              "button",
-              {
-                type: "button",
-                style: styles.controlButton,
-                onClick: resetView,
-                title: "Reset view",
-                "aria-label": "Reset view",
-              },
-              "Reset"
-            ),
-            React.createElement(
-              "button",
-              {
-                type: "button",
-                style: styles.controlButton,
-                onClick: undo,
-                title: "Undo last fill",
-                "aria-label": "Undo last fill",
-              },
-              "Undo"
             ),
             React.createElement(
               "button",
@@ -2102,7 +2419,7 @@ function OptionsPanel({ config, onToggle, canReset, onReset, onClose }) {
     },
     {
       title: "Header bar",
-      body: "Back affordance, artwork title, progress text, and utility buttons for fit, undo, hint, next color, tests, and options.",
+      body: "Back affordance, artwork title, progress text, and utility buttons for the library, options, hints, next color, and tests.",
     },
     {
       title: "Canvas frame",
@@ -2143,7 +2460,7 @@ function OptionsPanel({ config, onToggle, canReset, onReset, onClose }) {
       React.createElement(
         "p",
         { style: styles.optionsAbout },
-        "The project is a single-page React 18 color-by-number demo that boots entirely from index.html, pulling React, ReactDOM, and Babel from CDNs so the JSX logic can run in the browser without a build step. The art library import accepts JSON exports or annotated SVG files with data-cell-id/data-color-id metadata so new scenes can be added without editing code. It loads a predefined “Capybara Forest Retreat” scene inspired by a detailed 960×600 SVG reference (art/capybara-forest.svg) with 26 labeled, non-overlapping regions and an 11-color palette, then tracks each cell’s fill state so players can match colors to numbers."
+        "The project is a single-page React 18 color-by-number demo that boots entirely from index.html, pulling React, ReactDOM, and Babel from CDNs so the JSX logic can run in the browser without a build step. The art library import accepts JSON exports or annotated SVG files with data-cell-id/data-color-id metadata so new scenes can be added without editing code. It now ships with three sample scenes—“Capybara Lagoon Sunrise,” “Twilight Marsh Study,” and “Lush Green Forest Walk”—plus autosave that tracks each cell’s fill state so players can match colors to numbers."
       ),
       React.createElement("div", { style: styles.optionsSectionTitle }, "UI surfaces"),
       React.createElement(
@@ -2281,6 +2598,24 @@ const styles = {
     fontFamily: "'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui",
     color: "#f8fafc",
     background: "radial-gradient(circle at top, rgba(56, 189, 248, 0.12), #030712)",
+  },
+  bootstrapBanner: {
+    position: "fixed",
+    top: 64,
+    left: "50%",
+    transform: "translateX(-50%)",
+    maxWidth: "min(520px, calc(100% - 32px))",
+    padding: "10px 16px",
+    borderRadius: 14,
+    background: "rgba(248, 113, 113, 0.15)",
+    border: "1px solid rgba(248, 113, 113, 0.4)",
+    color: "#fecaca",
+    fontSize: 12,
+    textAlign: "center",
+    zIndex: 30,
+    boxShadow: "0 12px 32px rgba(2, 6, 23, 0.6)",
+    backdropFilter: "blur(10px)",
+    pointerEvents: "none",
   },
   canvas: {
     position: "absolute",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "http-server . -p 8000 -c-1",
     "dev": "http-server . -p 8000 -c-1",
     "test": "playwright test",
+    "build:fallbacks": "node tools/build-starter-fallbacks.js",
     "test:smoke": "playwright test tests/hello.spec.js",
     "test:ci": "playwright test --reporter=github --workers=2",
     "show-report": "playwright show-report",

--- a/tests/svg-quality.spec.js
+++ b/tests/svg-quality.spec.js
@@ -1,0 +1,153 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const STARTER_SVGS = [
+  'capybara-lagoon.svg',
+  'capybara-twilight.svg',
+  'lush-green-forest.svg',
+];
+
+function resolveSvgPath(fileName) {
+  return path.join(__dirname, '..', 'art', fileName);
+}
+
+test.describe('starter SVG quality', () => {
+  for (const fileName of STARTER_SVGS) {
+    test(`${fileName} parses cleanly and passes quality checks`, async ({ page }) => {
+      const svgPath = resolveSvgPath(fileName);
+      const svgMarkup = await fs.promises.readFile(svgPath, 'utf8');
+
+      await page.setContent('<!DOCTYPE html><html><body></body></html>');
+
+      const result = await page.evaluate((markup) => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(markup, 'image/svg+xml');
+        const issues = [];
+
+        const parserError = doc.querySelector('parsererror');
+        if (parserError) {
+          issues.push(
+            `Parser error: ${parserError.textContent?.trim() || 'Unknown parser error'}`
+          );
+          return { ok: false, issues };
+        }
+
+        const svgEl = doc.querySelector('svg');
+        if (!svgEl) {
+          issues.push('Missing <svg> root element.');
+          return { ok: false, issues };
+        }
+
+        const widthAttr = svgEl.getAttribute('width');
+        const heightAttr = svgEl.getAttribute('height');
+        const viewBoxAttr = svgEl.getAttribute('viewBox');
+        const width = Number.parseFloat(widthAttr ?? '');
+        const height = Number.parseFloat(heightAttr ?? '');
+        if (!Number.isFinite(width) || width <= 0) {
+          issues.push('Missing or invalid width attribute.');
+        }
+        if (!Number.isFinite(height) || height <= 0) {
+          issues.push('Missing or invalid height attribute.');
+        }
+        if (!viewBoxAttr) {
+          issues.push('Missing viewBox attribute.');
+        } else {
+          const parts = viewBoxAttr
+            .trim()
+            .split(/[ ,]+/)
+            .map((part) => Number.parseFloat(part))
+            .filter((value) => Number.isFinite(value));
+          if (parts.length < 4) {
+            issues.push('viewBox must contain four numeric values.');
+          }
+        }
+
+        const titleEl = doc.querySelector('svg > title');
+        const descEl = doc.querySelector('svg > desc');
+        if (!titleEl || !titleEl.textContent?.trim()) {
+          issues.push('Missing accessible <title> element.');
+        }
+        if (!descEl || !descEl.textContent?.trim()) {
+          issues.push('Missing accessible <desc> element.');
+        }
+
+        const regionNodes = Array.from(doc.querySelectorAll('svg > g[data-cell-id]'));
+        if (!regionNodes.length) {
+          issues.push('No paintable regions were found.');
+          return { ok: false, issues };
+        }
+
+        const regionIds = new Set();
+        const cellIds = new Set();
+
+        for (const group of regionNodes) {
+          const regionId = group.getAttribute('id');
+          if (!regionId) {
+            issues.push('Every region group must include an id attribute.');
+          } else if (regionIds.has(regionId)) {
+            issues.push(`Duplicate region id detected: ${regionId}`);
+          } else {
+            regionIds.add(regionId);
+          }
+
+          const cellId = group.getAttribute('data-cell-id');
+          if (!cellId || !/^c\d+$/i.test(cellId)) {
+            issues.push(`Invalid data-cell-id on ${regionId || 'a region group'}.`);
+          } else if (cellIds.has(cellId)) {
+            issues.push(`Duplicate data-cell-id detected: ${cellId}`);
+          } else {
+            cellIds.add(cellId);
+          }
+
+          const colorId = group.getAttribute('data-color-id');
+          if (!colorId || !colorId.toString().trim()) {
+            issues.push(`Missing data-color-id on ${regionId || cellId || 'a region group'}.`);
+          }
+
+          const colorName = group.getAttribute('data-color-name');
+          if (!colorName || !colorName.toString().trim()) {
+            issues.push(`Missing data-color-name on ${regionId || cellId || 'a region group'}.`);
+          }
+
+          const colorHex = group.getAttribute('data-color-hex');
+          if (!colorHex || !/^#(?:[0-9a-f]{3}){1,2}$/i.test(colorHex.trim())) {
+            issues.push(`Missing or invalid data-color-hex on ${regionId || cellId || 'a region group'}.`);
+          }
+
+          const title = group.querySelector('title');
+          if (!title || !title.textContent?.trim()) {
+            issues.push(`Missing region <title> for ${regionId || cellId || 'a region group'}.`);
+          }
+
+          const pathNodes = [];
+          if (group.tagName.toLowerCase() === 'path') {
+            pathNodes.push(group);
+          }
+          group.querySelectorAll('path').forEach((pathEl) => {
+            pathNodes.push(pathEl);
+          });
+
+          if (!pathNodes.length) {
+            issues.push(`Region ${regionId || cellId || 'unknown'} is missing path geometry.`);
+          }
+
+          for (const pathEl of pathNodes) {
+            const d = pathEl.getAttribute('d');
+            if (!d || !d.trim()) {
+              issues.push(`A path inside ${regionId || cellId || 'a region group'} is missing d data.`);
+            }
+            const fill = pathEl.getAttribute('fill');
+            if (fill && /^none$/i.test(fill.trim())) {
+              issues.push(`A path inside ${regionId || cellId || 'a region group'} uses fill="none".`);
+            }
+          }
+        }
+
+        return { ok: issues.length === 0, issues };
+      }, svgMarkup);
+
+      expect(result.ok, result.issues.join('\n')).toBeTruthy();
+    });
+  }
+});

--- a/tools/build-starter-fallbacks.js
+++ b/tools/build-starter-fallbacks.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+const targets = [
+  { id: 'starter-capybara-lagoon', file: path.join('art', 'capybara-lagoon.svg') },
+  { id: 'starter-twilight-marsh', file: path.join('art', 'capybara-twilight.svg') },
+  { id: 'starter-lush-forest', file: path.join('art', 'lush-green-forest.svg') },
+];
+
+const lines = [];
+lines.push('(function () {');
+lines.push('  const fallbackSvgs = {');
+
+for (let i = 0; i < targets.length; i += 1) {
+  const target = targets[i];
+  const svgPath = path.join(projectRoot, target.file);
+  if (!fs.existsSync(svgPath)) {
+    throw new Error(`Unable to locate ${target.file} while building inline fallbacks.`);
+  }
+  const svg = fs.readFileSync(svgPath, 'utf8').replace(/`/g, '\\`');
+  const comma = i === targets.length - 1 ? '' : ',';
+  lines.push(`    "${target.id}": String.raw\`${svg}\`${comma}`);
+}
+
+lines.push('  };');
+lines.push('  const globalStore = (window.__starterSvgFallbacks = window.__starterSvgFallbacks || {});');
+lines.push('  Object.assign(globalStore, fallbackSvgs);');
+lines.push('  const applyMarker = () => {');
+lines.push("    if (typeof document !== 'undefined' && document.body) {");
+lines.push("      document.body.setAttribute('data-inline-fallbacks', Object.keys(globalStore).join(','));");
+lines.push('    }');
+lines.push('  };');
+lines.push("  if (typeof document !== 'undefined' && document.readyState === 'loading') {");
+lines.push("    document.addEventListener('DOMContentLoaded', applyMarker, { once: true });");
+lines.push('  } else {');
+lines.push('    applyMarker();');
+lines.push('  }');
+lines.push('})();');
+
+fs.writeFileSync(path.join(projectRoot, 'art', 'starter-fallbacks.js'), `${lines.join('\n')}\n`, 'utf8');
+
+console.log('Updated art/starter-fallbacks.js with embedded SVG fallbacks.');

--- a/ui-review.md
+++ b/ui-review.md
@@ -1,7 +1,7 @@
 # UI Review Notes
 
 ## Positive Observations
-- The ultra-slim glass command rail now hugs the top edge in a single line, keeping library, options, reset, undo, hint, next, and testing controls visible without crowding the artwork.
+- The ultra-slim glass command rail now hugs the top edge in a single line, keeping library, options, hint, next, and testing controls visible without crowding the artwork.
 - Wheel zoom now eases smoothly toward the cursor and right-click drags mirror the left-button pan, so navigating the canvas feels responsive and predictable.
 - The integrated progress chip beside the artwork title makes it effortless to see completion percentage at a glance as you fill cells.
 - Slimmed palette bubbles still feel tactile thanks to the inset numbering and glow, and they give the composition more breathing room around the artwork.


### PR DESCRIPTION
## Summary
- remove the reset and undo toolbar buttons so the header only surfaces the essential library, options, hint, next, and tests controls
- normalize mouse wheel zoom and mouse-driven panning by cancelling default scroll/selection behavior and disabling selection on the SVG canvas
- refresh the UI review notes to match the slimmer command rail

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dfffc1441c8331ae19d60aebd7ee4a