### PR TITLE
Merge codex/run-tests-on-app-functions into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ tools, a save manager, and a configurable generator all live inside a single
 - **Instant image import.** Drag-and-drop or use the picker to feed bitmaps or
   previously exported JSON puzzles straight into the generator pipeline.
 - **Built-in capybara sample.** The "Capybara Springs" illustration now loads
-  automatically on boot so you can start painting without importing anything.
-  The vignette features an orange-balanced capybara lounging in a lagoon with a
-  curious dachshund, water mushrooms, and a distant waterfall, and the 🐹
-  command rail button instantly reloads it whenever you want a fresh board.
+  automatically on boot in the high detail preset (when no autosave is
+  available) so you can start painting without importing anything. The vignette
+  features an orange-balanced capybara lounging in a lagoon with a curious
+  dachshund, water mushrooms, and a distant waterfall, and the 🐹 command rail
+  button instantly reloads it whenever you want a fresh board while reflecting
+  whichever detail preset you last chose.
+- **Sample detail presets.** Low/Medium/High chips live on the onboarding hint
+  and inside Settings, instantly reloading the sample with tuned colour counts,
+  resize targets, k-means iterations, and smoothing passes so QA can cycle
+  between breezy ≈26-region boards, balanced ≈42-region sessions, or
+  high-fidelity ≈140-region showpieces.
 - **Detailed debug logging.** The Help sheet's live log now announces when the
   sample puzzle begins loading and when it completes, alongside fills, hints,
   zooms, background tweaks, fullscreen toggles, and ignored clicks, so QA can
@@ -27,6 +34,10 @@ tools, a save manager, and a configurable generator all live inside a single
   while optional auto-advance hops to the next unfinished colour. Filled areas
   now reveal the clustered artwork beneath the outlines so the illustration
   gradually emerges as you work.
+- **Mobile-friendly zoom guard.** Double-tap and pinch gestures no longer
+  trigger browser-level zoom; a global guard redirects them to the custom
+  canvas handlers so the HUD stays stable while pan/zoom gestures still feel
+  natural on touchscreens.
 - **Colour cues and feedback.** Choosing a swatch briefly pulses every matching
   region (falling back to a celebratory flash when a colour is finished) so
   it's obvious where to paint next, and correctly filled regions immediately
@@ -50,13 +61,35 @@ tools, a save manager, and a configurable generator all live inside a single
 - **Palette manager.** Swipe through compact, tinted swatches that promote the
   colour number while tooltips, titles, and ARIA copy preserve human-readable
   names and remaining region counts.
-- **Progress persistence & recovery.** Every stroke updates a rolling
-  autosave so the latest session is restored automatically on launch. Manual
-  snapshots still land in the save manager where you can rename, export, or
-  delete entries at will.
+- **Progress persistence & recovery.** Every stroke updates a rolling autosave
+  using a compact payload so the latest session is restored automatically on
+  launch. Manual snapshots still land in the save manager where you can rename,
+  export, or delete entries at will.
 - **Cloud-ready sync.** A lightweight broadcast channel mirrors autosaves
   across browser tabs and exposes a `window.capyCloudSync` adapter hook so
   teams can plug in remote storage when available.
+
+### Capybara Springs detail presets
+
+The Low/Medium/High detail chips on the onboarding hint and Settings sheet
+toggle tuned generator options for the built-in capybara vignette:
+
+| Preset | Colours | Approx. regions | Min region | Resize edge | Sample rate | Iterations | Smoothing | Use it when… |
+| ------ | ------- | --------------- | ---------- | ----------- | ----------- | ---------- | --------- | ------------ |
+| Low detail | 18 | ≈26 | 15 px² | 1216 px | 90% | 20 | 1 | Quick demos that favour broad shapes while keeping the characters readable. |
+| Medium detail | 26 | ≈42 | 8 px² | 1408 px | 95% | 24 | 1 | Balanced play sessions that capture the lagoon’s reflections without overwhelming region counts. |
+| High detail | 32 | ≈140 | 3 px² | 1536 px | 100% | 28 | 1 | Showcase captures where fur bands, ripples, and foliage clusters should stay distinct. |
+
+Each preset reloads the sample puzzle immediately, updates the generator
+sliders to mirror the chosen settings, and stamps the debug log with the
+relevant detail level so QA transcripts record every switch. The app boots in
+the high preset so playtesters immediately see the full ≈140-region canvas, but
+the remembered preset keeps medium or low runs sticky after you switch. The
+region counts above are based on the bundled Capybara Springs artwork and keep
+every preset playable—from the breezy ≈26-region low detail board to the
+≈140-region high fidelity scene. For a full tour of the palette and every
+numbered cell in the segmented source, see
+[`docs/capybara-springs-map.md`](docs/capybara-springs-map.md).
 
 ## Code architecture tour
 
@@ -113,15 +146,19 @@ tools, a save manager, and a configurable generator all live inside a single
 
 1. **Resume or load an image.** The app restores your most recent autosave on
    boot; if nothing is stored yet the bundled “Capybara Springs” puzzle loads
-   automatically so you can start painting immediately. Drag a bitmap into the
-   viewport, activate the “Choose an image” button, or press the 🐹 command
-   button to reload the bundled scene. The hint overlay disappears once a new
-   source is selected.
+   automatically in the high detail preset so you can start painting
+   immediately. Drag a bitmap into the viewport, activate the “Choose an image”
+   button, or press the 🐹 command button to reload the bundled scene. The hint
+   overlay disappears once a new source is selected, and the Low/Medium/High
+   detail chips can pre-seed the capybara sample with relaxed or high-fidelity
+   settings before you reload it.
 2. **Tune generation & appearance.** Open **Settings** to tweak palette size,
    minimum region area, resize detail, sample rate (for faster clustering),
-   iteration count, smoothing passes, auto-advance, hint animations, and the
-   canvas background colour. Apply changes instantly when working from an image
-   source.
+   iteration count, smoothing passes, auto-advance, hint animations, the canvas
+   background colour, and the new interface scale slider. Apply changes
+   instantly when working from an image source, then expand the **Advanced
+   options** accordion to edit the optional art prompt metadata before exporting
+   or regenerating a scene.
 3. **Explore the puzzle.** The game canvas shows outlines and number badges,
    while the **Preview** button floods the entire viewport with a fullscreen
    comparison of the clustered artwork.
@@ -129,8 +166,31 @@ tools, a save manager, and a configurable generator all live inside a single
    and the region fills in. Auto-advance can hop to the next incomplete colour
    once you finish the current hue.
 5. **Save or export.** The save manager captures snapshots (including progress,
-   generator options, and source metadata) in localStorage. Export the active
-   puzzle as JSON at any time.
+   generator options, and source metadata) in localStorage using a compact
+   schema. Export the active puzzle as JSON at any time.
+
+## Puzzle JSON format
+
+Autosaves, manual exports, and the Playwright fixtures all share a
+`capy-puzzle@2` payload. Key fields include:
+
+- `format` – Indicates the schema version (`capy-puzzle@2`).
+- `width`/`height` – Pixel dimensions of the clustered canvas.
+- `palette` – Colour entries with `id`, `hex`, and display `name`.
+- `regions` – Region metadata (`id`, `colorId`, centroid, and `pixelCount`).
+- `regionMapPacked` – Base64-encoded little-endian `Int32Array` describing
+  which region id occupies each pixel. Legacy imports can still provide a plain
+  `regionMap` array; the loader hydrates whichever is available and rebuilds the
+  per-region pixel lists on the fly.
+- `filled` – Region ids that the player has already painted.
+- `backgroundColor`, `options`, `activeColor`, `viewport`, `settings`, and
+  `sourceUrl` – The appearance and generator state needed to restore the session.
+
+Packing the region map trims autosave/export payloads by more than half compared
+to the old verbose arrays, which prevents the `QuotaExceededError` console
+messages browsers emitted when large puzzles overflowed localStorage. If storage
+does fill up, the app now logs a debug reminder prompting you to clear old saves
+before retrying.
 
 ## UI guide
 
@@ -146,7 +206,9 @@ tools, a save manager, and a configurable generator all live inside a single
   The canvas renders outlines, remaining numbers, and filled regions, respects
   auto-advance / hint animation toggles, and supports smooth pan + zoom so you
   can inspect fine details. Drag with the mouse or trackpad to reposition the
-  scene and use the scroll wheel (or trackpad gesture) to zoom.
+  scene and use the scroll wheel (or trackpad gesture) to zoom — mobile pinch
+  gestures now feed directly into the stage, and a double-tap guard keeps the
+  browser from scaling the interface accidentally while you navigate.
 - **Fullscreen preview overlay** – Triggered by the Preview button. The preview
   canvas stretches to fit the viewport so contributors can inspect the clustered
   output in detail before painting.
@@ -154,9 +216,16 @@ tools, a save manager, and a configurable generator all live inside a single
   completed versus total regions and announces updates politely via `aria-live`.
 - **Settings sheet** – A modal sheet that hides the generation sliders by
   default. Controls include colours, minimum region size, resize detail, sample
-  rate, k-means iterations, smoothing passes, a background colour picker, plus
-  toggles for auto-advance and hint animations. The sheet also houses the JSON
-  export action.
+  rate, k-means iterations, smoothing passes, a background colour picker, and
+  an interface scale slider, plus toggles for auto-advance and hint animations.
+  The sheet also houses the JSON export action, mirrors the Low/Medium/High
+  detail chips so you can reload the sample with tuned parameters without
+  leaving the modal, and tucks the art prompt query inside an **Advanced
+  options** accordion so casual play stays focused on painting.
+- **Detail presets** – The onboarding hint and Settings sheet both surface the
+  Low/Medium/High chips with a live caption describing the active preset so you
+  know how many colours, what minimum region size, and which resize edge (and
+  approximate region count) the next sample reload will use.
 - **Save manager** – A companion sheet listing every stored snapshot. Each entry
   shows completion progress with quick actions to load, rename, export, or
   delete the save.
@@ -197,9 +266,10 @@ The Playwright suite exercises the core flows:
 - **renders command rail and generator settings on load** – Confirms the hint
   overlay, iconized command rail, compact progress tally, and generator controls
   render on first boot.
-- **auto loads the capybara sample scene** – Verifies the bundled illustration is
-  ready as soon as the app boots and that the sample button still reloads it on
-  demand.
+ - **auto loads the capybara sample scene** – Verifies the bundled illustration is
+    ready as soon as the app boots, that the sample button still reloads it on
+    demand, and that the Low/Medium/High detail chips update generator sliders,
+    debug logging, and palette/region counts as expected.
 - **allows adjusting the canvas background colour** – Uses the fixture loader to
   set a new background via the exposed harness helper, verifies pixel data,
   and confirms the debug log records the change.

--- a/docs/gameplay-session.md
+++ b/docs/gameplay-session.md
@@ -9,15 +9,18 @@
 - Accessed the app at <http://localhost:8000/index.html> via an automated Chromium session (Playwright).
 
 ## Actions Performed
-1. Reloaded the page to confirm the new autosave pipeline restored the last
+1. Reloaded the page to confirm the autosave pipeline restored the last
    in-progress puzzle; with no prior data the "Capybara Springs" scene still
-   loads automatically, showcasing the orange-crowned capybara, loyal
-   dachshund, waterfall, and mushroom-ring lagoon. Pressed the 🐹 command button
-   afterwards to force a fresh board and confirm the shortcut still works
-   without reopening the hint overlay.
-2. Selected the first palette swatch to activate its associated colour and
+   loads automatically in the high detail preset, showcasing the
+   orange-crowned capybara, loyal dachshund, waterfall, and mushroom-ring
+   lagoon. Pressed the 🐹 command button afterwards to force a fresh board and
+   confirm the shortcut still works without reopening the hint overlay.
+2. Clicked the Low/Medium/High detail chips to confirm each preset updates the
+   generator sliders, reloads the sample with the expected ≈26/≈42/≈140 region
+   breakdowns, and writes its summary to the debug log.
+3. Selected the first palette swatch to activate its associated colour and
    watched the matching regions flash for guidance.
-3. Dragged the canvas with mouse and touch, pinched to zoom, toggled
+4. Dragged the canvas with mouse and touch, pinched to zoom, toggled
    fullscreen, and filled a highlighted region to confirm the viewport recenters
    cleanly at every scale.
 
@@ -25,11 +28,23 @@
 - Artwork, palette, and the top-right hint/menu controls rendered without errors once the page finished hydrating, and the bundled sample was already playable before touching any UI.
 - The top-right command rail now shows icon-only controls (including the fullscreen toggle) tucked to the right edge so opening settings or the save manager never obscures the artwork.
 - Palette selection immediately highlighted the active swatch, flashed every matching region (with a celebratory flash once a colour is complete), and kept the compact number-only label crisp while remaining counts surfaced via tooltip copy.
-- Tweaking the new background colour control instantly repainted unfinished regions and flipped numeral contrast, so a darker backdrop stayed readable while painting.
+- Tweaking the background colour control instantly repainted unfinished regions and flipped numeral contrast, and the new interface scale slider resized the command rail and palette without touching puzzle zoom so HUD tweaks no longer require custom CSS.
+- The generator's art prompt query now lives inside a collapsed Advanced options panel in Settings, keeping the onboarding hint clean while still letting us document the inspiration alongside saves and exports when needed.
 - Painting a cell updated the fill colour inline with the clustered artwork (no refresh needed) and click-drag panning, pinch/scroll zoom, plus `+`/`-` keyboard shortcuts made it easy to inspect tiny regions. Entering and exiting fullscreen (or rotating the device) recentred the canvas automatically.
+- Mobile pinch gestures now stay focused on the canvas — the viewport meta clamps browser zoom and a double-tap guard blocks accidental page scaling while still letting our custom pan/zoom math run.
 - The refreshed Help sheet documents every icon command (including fullscreen), reiterates the gesture controls, and streams a live debug log so it was easy to verify hints, fills, zooms, and orientation changes during the session.
-- Debug logging now captures ignored clicks (no puzzle, wrong colour, filled regions), viewport orientation changes, fullscreen transitions, background updates, autosave restore messages, and both the start and completion of sample reloads which helped confirm why certain taps were rejected while exercising the canvas.
-- Rolling autosaves hit local storage on each stroke and immediately mirror to any open tabs via the new cloud sync channel, so the session resumed intact after hard refreshes.
+- Debug logging now captures ignored clicks (no puzzle, wrong colour, filled
+  regions), viewport orientation changes, fullscreen transitions, background
+  updates, autosave restore messages, and both the start and completion of
+  sample reloads which helped confirm why certain taps were rejected while
+  exercising the canvas.
+- Detail preset switches add "Loading <preset> detail" entries before the usual
+  completion log, and the Settings sheet mirrors the same chips for mid-session
+  adjustments, making it easy to trace which configuration produced a given
+  palette or region count (≈26 for low, ≈42 for medium, ≈140 for high).
+- Rolling autosaves hit local storage on each stroke and immediately mirror to
+  any open tabs via the new cloud sync channel, so the session resumed intact
+  after hard refreshes.
 - Overall responsiveness stayed smooth during the brief automation-driven play session.
 
 ## Follow-up Ideas

--- a/index.html
+++ b/index.html
@@ -23,7 +23,10 @@
   -->
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>Image to Color-by-Number</title>
     <style>
       :root {
@@ -32,13 +35,24 @@
           sans-serif;
         background: #020617;
         color: #e2e8f0;
+        --ui-scale: 1;
         --app-width: 100vw;
         --app-height: 100vh;
-        --viewport-padding: 32px;
+        --viewport-padding: calc(32px * var(--ui-scale));
+        --rail-gap: calc(8px * var(--ui-scale));
+        --rail-gap-portrait: calc(6px * var(--ui-scale));
+        --rail-padding-block: calc(12px * var(--ui-scale));
+        --rail-padding-inline: calc(24px * var(--ui-scale));
+        --command-button-size: calc(40px * var(--ui-scale));
+        --command-button-size-portrait: calc(36px * var(--ui-scale));
       }
 
       * {
         box-sizing: border-box;
+      }
+
+      html {
+        touch-action: manipulation;
       }
 
       body {
@@ -48,6 +62,9 @@
           #020617;
         color: inherit;
         overflow: hidden;
+        font-size: calc(16px * var(--ui-scale));
+        touch-action: manipulation;
+        overscroll-behavior: none;
       }
 
       body.sheet-open {
@@ -76,16 +93,17 @@
         display: flex;
         justify-content: flex-end;
         align-items: center;
-        gap: 8px;
-        padding: 12px 24px;
+        gap: var(--rail-gap);
+        padding: var(--rail-padding-block) var(--rail-padding-inline);
         z-index: 3;
+        touch-action: manipulation;
       }
 
       #commandRail button {
         border-radius: 12px;
         padding: 0;
-        width: 40px;
-        height: 40px;
+        width: var(--command-button-size);
+        height: var(--command-button-size);
         display: grid;
         place-items: center;
         background: rgba(15, 23, 42, 0.82);
@@ -112,13 +130,13 @@
 
       body[data-orientation="portrait"] #commandRail {
         flex-wrap: wrap;
-        gap: 6px;
-        padding: 12px 16px;
+        gap: var(--rail-gap-portrait);
+        padding: var(--rail-padding-block) calc(16px * var(--ui-scale));
       }
 
       body[data-orientation="portrait"] #commandRail button {
-        width: 36px;
-        height: 36px;
+        width: var(--command-button-size-portrait);
+        height: var(--command-button-size-portrait);
       }
 
       body[data-orientation="portrait"] #paletteDock {
@@ -210,14 +228,14 @@
       #previewOverlay canvas {
         width: min(100%, calc(100vh - 140px));
         height: auto;
-        border-radius: 20px;
+        border-radius: calc(20px * var(--ui-scale));
         border: 1px solid rgba(148, 163, 184, 0.4);
         box-shadow: 0 32px 70px rgba(2, 6, 23, 0.65);
         image-rendering: pixelated;
       }
 
       #previewOverlay button {
-        margin-top: 24px;
+        margin-top: calc(24px * var(--ui-scale));
       }
 
       #startHint {
@@ -244,13 +262,13 @@
         pointer-events: auto;
         text-align: center;
         max-width: 360px;
-        padding: 32px;
-        border-radius: 20px;
+        padding: calc(32px * var(--ui-scale));
+        border-radius: calc(20px * var(--ui-scale));
         background: rgba(2, 6, 23, 0.78);
         border: 1px solid rgba(59, 130, 246, 0.35);
         box-shadow: 0 20px 60px rgba(15, 23, 42, 0.6);
         display: grid;
-        gap: 20px;
+        gap: calc(20px * var(--ui-scale));
         justify-items: center;
       }
 
@@ -266,24 +284,82 @@
       }
 
       #startHint .sample-art {
-        width: min(240px, 70vw);
+        width: min(calc(240px * var(--ui-scale)), 70vw);
         max-width: 100%;
-        border-radius: 16px;
+        border-radius: calc(16px * var(--ui-scale));
         box-shadow: 0 16px 40px rgba(15, 23, 42, 0.55);
         border: 1px solid rgba(148, 163, 184, 0.25);
       }
 
       #startHint .hint-actions {
         display: grid;
-        gap: 12px;
+        gap: calc(12px * var(--ui-scale));
         width: 100%;
       }
 
+        .detail-callout {
+          display: grid;
+          gap: calc(12px * var(--ui-scale));
+          width: 100%;
+          text-align: center;
+        }
+
+        .detail-intro {
+          margin: 0;
+          font-size: 0.95rem;
+          color: rgba(226, 232, 240, 0.82);
+        }
+
+        .detail-picker {
+          display: flex;
+          justify-content: center;
+          gap: calc(8px * var(--ui-scale));
+          flex-wrap: wrap;
+        }
+
+        button.detail-chip {
+          padding: 6px 16px;
+          border-radius: 999px;
+          border: 1px solid rgba(148, 163, 184, 0.35);
+          background: rgba(15, 23, 42, 0.65);
+          color: rgba(226, 232, 240, 0.85);
+          font-weight: 600;
+          font-size: 0.85rem;
+          letter-spacing: 0.01em;
+          box-shadow: none;
+        }
+
+        button.detail-chip:hover:not(:disabled) {
+          transform: none;
+          box-shadow: none;
+          background: rgba(37, 99, 235, 0.25);
+          color: rgba(226, 232, 240, 0.95);
+        }
+
+        button.detail-chip[aria-pressed="true"] {
+          background: rgba(59, 130, 246, 0.35);
+          border-color: rgba(147, 197, 253, 0.6);
+          color: rgba(226, 232, 240, 0.98);
+        }
+
+        .detail-caption {
+          margin: 0;
+          font-size: 0.85rem;
+          color: rgba(148, 163, 184, 0.85);
+        }
+
+        #settingsSheet .detail-callout {
+          text-align: left;
+        }
+
+        #settingsSheet .detail-picker {
+          justify-content: flex-start;
+        }
       button {
         font: inherit;
         border-radius: 999px;
         border: none;
-        padding: 10px 22px;
+        padding: calc(10px * var(--ui-scale)) calc(22px * var(--ui-scale));
         background: rgba(96, 165, 250, 0.92);
         color: #021027;
         font-weight: 600;
@@ -309,11 +385,15 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 16px;
-        padding: 16px 28px 24px;
+        gap: calc(16px * var(--ui-scale));
+        padding:
+          calc(16px * var(--ui-scale))
+          calc(28px * var(--ui-scale))
+          calc(24px * var(--ui-scale));
         background: linear-gradient(180deg, rgba(2, 6, 23, 0) 0%, rgba(2, 6, 23, 0.85) 40%, rgba(2, 6, 23, 0.95) 100%);
         border-top: 1px solid rgba(30, 41, 59, 0.7);
         box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+        touch-action: manipulation;
       }
 
       #progress {
@@ -328,15 +408,15 @@
         flex: 1;
         display: grid;
         grid-auto-flow: column;
-        grid-auto-columns: minmax(44px, 1fr);
-        gap: 6px;
+        grid-auto-columns: minmax(calc(44px * var(--ui-scale)), 1fr);
+        gap: calc(6px * var(--ui-scale));
         overflow-x: auto;
-        padding: 2px 0 6px;
+        padding: 2px 0 calc(6px * var(--ui-scale));
         scrollbar-width: thin;
       }
 
       #palette::-webkit-scrollbar {
-        height: 6px;
+        height: calc(6px * var(--ui-scale));
       }
 
       #palette::-webkit-scrollbar-thumb {
@@ -347,7 +427,7 @@
       .control {
         display: flex;
         flex-direction: column;
-        gap: 6px;
+        gap: calc(6px * var(--ui-scale));
         font-size: 0.95rem;
       }
 
@@ -361,6 +441,62 @@
       .control output {
         font-size: 0.85rem;
         color: rgba(148, 163, 184, 0.9);
+      }
+
+      details.advanced-options {
+        margin-top: calc(16px * var(--ui-scale));
+        padding: calc(12px * var(--ui-scale));
+        border-radius: calc(12px * var(--ui-scale));
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.45);
+      }
+
+      details.advanced-options[open] {
+        background: rgba(15, 23, 42, 0.6);
+      }
+
+      details.advanced-options summary {
+        list-style: none;
+        cursor: pointer;
+        font-weight: 600;
+        margin-bottom: calc(8px * var(--ui-scale));
+        display: flex;
+        align-items: center;
+        gap: calc(6px * var(--ui-scale));
+      }
+
+      details.advanced-options summary::after {
+        content: "▾";
+        font-size: 0.85rem;
+        opacity: 0.7;
+        transform: rotate(0deg);
+        transition: transform 0.2s ease;
+      }
+
+      details.advanced-options[open] summary::after {
+        transform: rotate(180deg);
+      }
+
+      #artPrompt {
+        width: 100%;
+        min-height: calc(120px * var(--ui-scale));
+        padding: calc(10px * var(--ui-scale));
+        border-radius: calc(12px * var(--ui-scale));
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.85);
+        color: inherit;
+        font: inherit;
+        resize: vertical;
+      }
+
+      #artPrompt:focus {
+        outline: none;
+        border-color: rgba(96, 165, 250, 0.7);
+        box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+      }
+
+      #artPrompt::placeholder {
+        color: rgba(148, 163, 184, 0.7);
       }
 
       input[type="range"] {
@@ -447,10 +583,10 @@
         align-items: center;
         justify-content: center;
         gap: 2px;
-        padding: 6px;
-        min-width: 44px;
-        min-height: 52px;
-        border-radius: 12px;
+        padding: calc(6px * var(--ui-scale));
+        min-width: calc(44px * var(--ui-scale));
+        min-height: calc(52px * var(--ui-scale));
+        border-radius: calc(12px * var(--ui-scale));
         border: 1px solid rgba(148, 163, 184, 0.25);
         background:
           linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.82));
@@ -463,8 +599,8 @@
       .swatch::before {
         content: "";
         position: absolute;
-        inset: 4px;
-        border-radius: 10px;
+        inset: calc(4px * var(--ui-scale));
+        border-radius: calc(10px * var(--ui-scale));
         background:
           linear-gradient(140deg, rgba(15, 23, 42, 0.06), rgba(15, 23, 42, 0.28)),
           var(--swatch-color, transparent);
@@ -889,6 +1025,15 @@
               Drag a picture anywhere on the screen, choose a file from your device,
               or jump straight into our capybara sample scene.
             </p>
+              <div class="detail-callout">
+                <p class="detail-intro">Pick a detail level for the capybara demo:</p>
+                <div class="detail-picker" role="group" aria-label="Capybara sample detail level">
+                  <button type="button" class="detail-chip" data-detail-level="low">Low</button>
+                  <button type="button" class="detail-chip" data-detail-level="medium">Medium</button>
+                  <button type="button" class="detail-chip" data-detail-level="high">High</button>
+                </div>
+                <p class="detail-caption" data-detail-caption></p>
+              </div>
             <div class="hint-actions">
               <button id="selectImage" type="button">Choose an image</button>
               <button
@@ -932,7 +1077,15 @@
             <dt>🖼 Preview</dt>
             <dd>Toggle the finished artwork overlay to compare your progress.</dd>
             <dt>🐹 Sample</dt>
-            <dd>Reload the built-in capybara puzzle for a fresh board.</dd>
+              <dd>
+                Reload the built-in capybara puzzle for a fresh board. Pair it with the Low/Medium/High
+                detail presets to jump between ≈26, ≈42, or ≈140 regions.
+              </dd>
+              <dt>🎚 Detail</dt>
+              <dd>
+                Toggle the capybara detail chips (start hint or Settings) to reload the sample with tuned
+                palette sizes, minimum region areas, resize targets, and the region counts noted above.
+              </dd>
             <dt>⛶ Fullscreen</dt>
             <dd>Expand the app to fill the display or exit back to windowed mode.</dd>
             <dt>⬆ Import</dt>
@@ -942,7 +1095,10 @@
             <dt>ℹ Help</dt>
             <dd>Open this guide and inspect the live debug log.</dd>
             <dt>⚙ Settings</dt>
-            <dd>Adjust generation sliders, toggle auto-advance, customise the background, or export JSON.</dd>
+            <dd>
+              Adjust generation sliders, toggle auto-advance, customise the background, resize the interface, or export JSON.
+              Expand Advanced options to edit the hidden art prompt metadata when you need to capture the original brief.
+            </dd>
           </dl>
         </section>
         <section class="sheet-section" aria-labelledby="controlsHeading">
@@ -1005,9 +1161,33 @@
           <p class="control-note">
             Applies to unfinished regions and adjusts outline contrast automatically.
           </p>
+          <label class="control">
+            <span>Interface scale <output data-for="uiScale">100%</output></span>
+            <input
+              id="uiScale"
+              type="range"
+              min="0.85"
+              max="1.35"
+              step="0.05"
+              value="1"
+            />
+          </label>
+          <p class="control-note">Resize command buttons and labels without altering canvas zoom.</p>
         </section>
         <section class="sheet-section" aria-labelledby="generatorHeading">
           <h3 id="generatorHeading">Generator</h3>
+          <div class="detail-callout">
+            <p class="detail-intro">Capybara sample detail presets</p>
+            <div class="detail-picker" role="group" aria-label="Capybara sample detail presets">
+              <button type="button" class="detail-chip" data-detail-level="low">Low</button>
+              <button type="button" class="detail-chip" data-detail-level="medium">Medium</button>
+              <button type="button" class="detail-chip" data-detail-level="high">High</button>
+            </div>
+            <p class="detail-caption" data-detail-caption></p>
+          </div>
+          <p class="control-note">
+            Switching presets updates the sliders below and reloads the sample scene when it's active.
+          </p>
           <label class="control">
             <span>Colours <output data-for="colorCount">16</output></span>
             <input id="colorCount" type="range" min="4" max="64" value="16" />
@@ -1035,6 +1215,20 @@
             <span>Smoothing passes <output data-for="smoothingPasses">1</output></span>
             <input id="smoothingPasses" type="range" min="0" max="4" step="1" value="1" />
           </label>
+          <details class="advanced-options" id="generatorAdvanced">
+            <summary>Advanced options</summary>
+            <label class="control">
+              <span>Art prompt</span>
+              <textarea
+                id="artPrompt"
+                rows="3"
+                placeholder="Describe the scene you want to reinterpret"
+              ></textarea>
+            </label>
+            <p class="control-note">
+              Stored with saves and exports so you can revisit the inspiration later.
+            </p>
+          </details>
         </section>
       </div>
       <div class="sheet-actions">
@@ -1064,6 +1258,8 @@
       const fileInput = document.getElementById("fileInput");
       const selectButton = document.getElementById("selectImage");
       const sampleButtons = Array.from(document.querySelectorAll('[data-action="load-sample"]'));
+        const sampleDetailButtons = Array.from(document.querySelectorAll('[data-detail-level]'));
+        const sampleDetailCaptions = Array.from(document.querySelectorAll('[data-detail-caption]'));
       const samplePreview = document.getElementById("sampleArtPreview");
       const startHint = document.getElementById("startHint");
       const hintButton = document.getElementById("hintButton");
@@ -1088,12 +1284,14 @@
       const autoAdvanceToggle = document.getElementById("autoAdvanceToggle");
       const hintFlashToggle = document.getElementById("hintFlashToggle");
       const backgroundColorInput = document.getElementById("backgroundColor");
+      const uiScaleInput = document.getElementById("uiScale");
       const colorCountEl = document.getElementById("colorCount");
       const minRegionEl = document.getElementById("minRegion");
       const detailEl = document.getElementById("detailLevel");
       const sampleRateEl = document.getElementById("sampleRate");
       const kmeansItersEl = document.getElementById("kmeansIters");
       const smoothingEl = document.getElementById("smoothingPasses");
+      const artPromptInput = document.getElementById("artPrompt");
       const applyBtn = document.getElementById("applyOptions");
       const downloadBtn = document.getElementById("downloadJson");
       const saveSnapshotBtn = document.getElementById("saveSnapshot");
@@ -1113,6 +1311,7 @@
         sample: settingsSheet.querySelector('output[data-for="sampleRate"]'),
         iterations: settingsSheet.querySelector('output[data-for="kmeansIters"]'),
         smoothing: settingsSheet.querySelector('output[data-for="smoothingPasses"]'),
+        uiScale: settingsSheet.querySelector('output[data-for="uiScale"]'),
       };
       const SAVE_STORAGE_KEY = "capy.saves.v2";
       const AUTOSAVE_STORAGE_KEY = "capy.autosave.v1";
@@ -1123,15 +1322,121 @@
       const cloudSync = createCloudSync();
       let autosaveTimer = null;
       let pendingAutosaveReason = null;
+      let preventingBrowserZoom = false;
+      const DOUBLE_TAP_GUARD_MS = 350;
+
+      function isInteractiveElementForZoomGuard(node) {
+        return (
+          node instanceof Element &&
+          Boolean(
+            node.closest(
+              "input, textarea, select, button, [role=\"button\"], [role=\"textbox\"], [role=\"slider\"], [contenteditable=\"true\"]"
+            )
+          )
+        );
+      }
+
+      function installBrowserZoomGuards() {
+        if (typeof window === "undefined") return;
+        let lastTouchEndTime = 0;
+
+        window.addEventListener(
+          "touchend",
+          (event) => {
+            const now = Date.now();
+            const remainingTouches = event.touches ? event.touches.length : 0;
+            if (remainingTouches === 0 && now - lastTouchEndTime <= DOUBLE_TAP_GUARD_MS) {
+              if (!isInteractiveElementForZoomGuard(event.target)) {
+                event.preventDefault();
+              }
+            }
+            lastTouchEndTime = now;
+          },
+          { passive: false }
+        );
+
+        ["gesturestart", "gesturechange", "gestureend"].forEach((type) => {
+          window.addEventListener(
+            type,
+            (event) => {
+              if (event && typeof event.preventDefault === "function") {
+                event.preventDefault();
+              }
+            },
+            { passive: false }
+          );
+        });
+
+        preventingBrowserZoom = true;
+      }
 
       // Embedded sample used for onboarding and smoke tests.
       const SAMPLE_ARTWORK = {
         title: "Capybara Springs",
         description: "A capybara with an orange crown relaxes beside a dachshund in a forest lagoon.",
         dataUrl:
-          "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMjAgMjQwIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ic2t5IiB4MT0iMCIgeDI9IjAiIHkxPSIwIiB5Mj0iMSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2Y5ZThjOCIgLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjOGNjMGZmIiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0id2F0ZXIiIHgxPSIwIiB4Mj0iMCIgeTE9IjAiIHkyPSIxIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjNGU4Y2M5IiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNDRiNzQiIC8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJoaWxsIiB4MT0iMCIgeTE9IjAiIHgyPSIwIiB5Mj0iMSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzNmN2IzZiIgLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMjM1NzJmIiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0ic3VuIiBjeD0iMC4xIiBjeT0iMC4xIiByPSIwLjgiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNmZmY3YzMiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2YyYTkzYSIgLz4KICAgIDwvcmFkaWFsR3JhZGllbnQ+CiAgPC9kZWZzPgogIDxyZWN0IHdpZHRoPSIzMjAiIGhlaWdodD0iMTYwIiBmaWxsPSJ1cmwoI3NreSkiIC8+CiAgPHJlY3QgeT0iMTQwIiB3aWR0aD0iMzIwIiBoZWlnaHQ9IjEwMCIgZmlsbD0idXJsKCN3YXRlcikiIC8+CiAgPGVsbGlwc2UgY3g9IjI2MCIgY3k9IjY1IiByeD0iMjgiIHJ5PSIyOCIgZmlsbD0idXJsKCNzdW4pIiBvcGFjaXR5PSIwLjkiIC8+CiAgPHBhdGggZD0iTTAgMTIwIFE4MCA2MCAxNjAgMTIwIFQzMjAgMTIwIFYxNzAgSDAgWiIgZmlsbD0idXJsKCNoaWxsKSIgLz4KICA8cGF0aCBkPSJNMjgwIDQwIFEyNzAgMTEwIDMwMCAxMzAgTDMwMCAxNjAgUTI1MCAxNDAgMjYwIDgwIiBmaWxsPSIjNzRhMmRlIiBvcGFjaXR5PSIwLjciIC8+CiAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNTIsMTIwKSI+CiAgICA8cGF0aCBkPSJNMjggMjggcTQwIC00MCA5NiAtMTggdDcyIDYwIHEtOCAzNiAtNDYgNDQgbC05MCA0IHEtNDAgLTYgLTUyIC0zNiB0MjAgLTU0IHoiIGZpbGw9IiNjMzhhNTUiIC8+CiAgICA8cGF0aCBkPSJNMzggMjYgcTIyIC0yMiA0NCAtMjQgdDQ2IDEyIHEyMCAxMCAzMiAzMCB0NCA0NCBxLTQgMjQgLTMyIDMyIGwtNjIgNiBxLTM0IDAgLTQ2IC0yMCB0LTIgLTQ4IHoiIGZpbGw9IiNhZTc0NDIiIC8+CiAgICA8ZWxsaXBzZSBjeD0iODYiIGN5PSI2NiIgcng9IjE2IiByeT0iMjAiIGZpbGw9IiNmNWM5OTUiIC8+CiAgICA8ZWxsaXBzZSBjeD0iNjAiIGN5PSI3NiIgcng9IjE4IiByeT0iMjIiIGZpbGw9IiNiOTdiNDMiIC8+CiAgICA8ZWxsaXBzZSBjeD0iMTA4IiBjeT0iNTYiIHJ4PSIxNCIgcnk9IjE4IiBmaWxsPSIjYjk3YjQzIiAvPgogICAgPGVsbGlwc2UgY3g9IjE0NiIgY3k9IjY0IiByeD0iMzIiIHJ5PSIzOCIgZmlsbD0iI2Q0OWI2MiIgLz4KICAgIDxlbGxpcHNlIGN4PSIxNjQiIGN5PSI3MCIgcng9IjIwIiByeT0iMjQiIGZpbGw9IiNjMzhhNTUiIC8+CiAgICA8ZWxsaXBzZSBjeD0iMTcwIiBjeT0iODAiIHJ4PSIxMCIgcnk9IjEyIiBmaWxsPSIjNzg0ZjMyIiAvPgogICAgPGVsbGlwc2UgY3g9IjEzNCIgY3k9IjYwIiByeD0iNiIgcnk9IjgiIGZpbGw9IiMyZDFjMTAiIC8+CiAgICA8ZWxsaXBzZSBjeD0iMTg4IiBjeT0iNzQiIHJ4PSI2IiByeT0iOCIgZmlsbD0iIzJkMWMxMCIgLz4KICAgIDxwYXRoIGQ9Ik0xNDAgOTYgcTE2IDEwIDMyIDAiIHN0cm9rZT0iIzJkMWMxMCIgc3Ryb2tlLXdpZHRoPSI0IiBzdHJva2UtbGluZWNhcD0icm91bmQiIGZpbGw9Im5vbmUiIC8+CiAgICA8cGF0aCBkPSJNMTIyIDMyIHEyMCAtMjYgNDQgLTIyIHQ0MCAyNCBsLTEyIDggcS0yNCAtMTggLTQwIC0xOCB0LTMyIDEyIHoiIGZpbGw9IiNiNTc0MzUiIC8+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDMsLTE4KSI+CiAgICAgIDxlbGxpcHNlIGN4PSIxMCIgY3k9IjEwIiByeD0iMTIiIHJ5PSIxMiIgZmlsbD0iI2YzN2IyNSIgLz4KICAgICAgPHBhdGggZD0iTTYgNiBsLTQgLTgiIHN0cm9rZT0iIzJkNjcyOSIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiIC8+CiAgICAgIDxwYXRoIGQ9Ik0xMCA1IHE0IC02IDEwIC0xMCIgc3Ryb2tlPSIjMmQ2NzI5IiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgLz4KICAgIDwvZz4KICA8L2c+CiAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTg0LDE1NikiPgogICAgPHBhdGggZD0iTTAgMTQgcTEwIC0xOCAzMCAtMTggdDM2IDE2IHExMCAxNiAyIDMyIHQtMzAgMjAgcS0yNCA0IC0zNiAtOCB0LTEyIC0yOCBxMCAtOCAxMCAtMTQgeiIgZmlsbD0iIzhlNTIyOCIgLz4KICAgIDxlbGxpcHNlIGN4PSIzMCIgY3k9IjM4IiByeD0iMTgiIHJ5PSIxNiIgZmlsbD0iI2E3NjUzNCIgLz4KICAgIDxlbGxpcHNlIGN4PSI1NCIgY3k9IjM2IiByeD0iMTYiIHJ5PSIxMiIgZmlsbD0iI2JjN2E0NSIgLz4KICAgIDxlbGxpcHNlIGN4PSI3MCIgY3k9IjM0IiByeD0iMTIiIHJ5PSIxMCIgZmlsbD0iIzc4NDMyNCIgLz4KICAgIDxlbGxpcHNlIGN4PSI3MiIgY3k9IjMyIiByeD0iNCIgcnk9IjYiIGZpbGw9IiMyZDFjMTAiIC8+CiAgICA8cGF0aCBkPSJNMzAgMTYgcTE0IC02IDIyIDYiIHN0cm9rZT0iIzJkMWMxMCIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiIC8+CiAgPC9nPgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMyLDE4NikiPgogICAgPGVsbGlwc2UgY3g9IjEyIiBjeT0iMTIiIHJ4PSIxMiIgcnk9IjEyIiBmaWxsPSIjZmJjZGQxIiAvPgogICAgPHJlY3QgeD0iOCIgeT0iMiIgd2lkdGg9IjgiIGhlaWdodD0iMTYiIHJ4PSI0IiBmaWxsPSIjZDU1ODY0IiAvPgogICAgPGNpcmNsZSBjeD0iMTIiIGN5PSI0IiByPSIzIiBmaWxsPSIjZmZmIiAvPgogIDwvZz4KICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg3MCwxOTgpIj4KICAgIDxlbGxpcHNlIGN4PSIxMCIgY3k9IjEwIiByeD0iMTAiIHJ5PSIxMCIgZmlsbD0iI2ZiZDdhOCIgLz4KICAgIDxyZWN0IHg9IjYiIHk9IjIiIHdpZHRoPSI4IiBoZWlnaHQ9IjE0IiByeD0iNCIgZmlsbD0iI2QxNmYzMyIgLz4KICAgIDxjaXJjbGUgY3g9IjEwIiBjeT0iNCIgcj0iMyIgZmlsbD0iI2ZmZiIgLz4KICA8L2c+CiAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjgwLDE4OCkiPgogICAgPGVsbGlwc2UgY3g9IjEwIiBjeT0iMTAiIHJ4PSIxMCIgcnk9IjEwIiBmaWxsPSIjZmJkN2E4IiAvPgogICAgPHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjgiIGhlaWdodD0iMTQiIHJ4PSI0IiBmaWxsPSIjZDE2ZjMzIiAvPgogICAgPGNpcmNsZSBjeD0iMTAiIGN5PSI0IiByPSIzIiBmaWxsPSIjZmZmIiAvPgogIDwvZz4KICA8cGF0aCBkPSJNNDAgMjAwIHE2MCAyMCAxNDAgMCB0MTIwIDEyIHEtNDggMjQgLTE2MCAyMCB0LTE0MCAtMzIgcTIwIC0xMiA0MCAwIHoiIGZpbGw9IiMzZDZkYTUiIG9wYWNpdHk9IjAuNiIgLz4KPC9zdmc+Cg==",
+          "data:image/svg+xml;base64,PCEtLSBDYXB5YmFyYSBMYWdvb24gU3VucmlzZSAtIFNlZ21lbnRlZCBTVkcgLS0+CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgOTYwIDYwMCIgd2lkdGg9Ijk2MCIgaGVpZ2h0PSI2MDAiIHJvbGU9ImltZyIgYXJpYS1sYWJlbGxlZGJ5PSJ0aXRsZSBkZXNjIj4KICA8dGl0bGUgaWQ9InRpdGxlIj5DYXB5YmFyYSBMYWdvb24gU3VucmlzZTwvdGl0bGU+CiAgPGRlc2MgaWQ9ImRlc2MiPkxheWVyZWQgc3VucmlzZSBiYW5kcyBvdmVyIGEgbGFnb29uIHdpdGggYSBzdHlsaXplZCBjYXB5YmFyYSBvbiB0aGUgc2hvcmUuPC9kZXNjPgogIDxnIGlkPSJyZWdpb24tYzAxIiBkYXRhLWNlbGwtaWQ9ImMxIiBkYXRhLWNvbG9yLWlkPSIxIiBkYXRhLWNvbG9yLW5hbWU9IlN1bnJpc2UgU2t5IiBkYXRhLWNvbG9yLWhleD0iI2Y2YmY2MCIgZmlsbD0iI2Y2YmY2MCI+CiAgICA8dGl0bGU+UmVnaW9uIGMxIOKAkyBDb2xvciAjMSAoU3VucmlzZSBTa3kpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0wIDAgTDk2MCAwIEw5NjAgODAgQyA4MjAgNzAgNjgwIDY4IDU0MCA3MiBDIDM4MCA3OCAyMjAgODYgMCA4MCBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzAyIiBkYXRhLWNlbGwtaWQ9ImMyIiBkYXRhLWNvbG9yLWlkPSIxIiBkYXRhLWNvbG9yLW5hbWU9IlN1bnJpc2UgU2t5IiBkYXRhLWNvbG9yLWhleD0iI2Y2YmY2MCIgZmlsbD0iI2Y2YmY2MCI+CiAgICA8dGl0bGU+UmVnaW9uIGMyIOKAkyBDb2xvciAjMSAoU3VucmlzZSBTa3kpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0wIDgwIEMgMjAwIDkwIDM2MCA4NiA1NDAgODAgQyA3MjAgNzQgODYwIDc2IDk2MCA4MCBMOTYwIDE0OCBDIDgyMCAxNDIgNjgwIDE0OCA1MjAgMTU2IEMgMzYwIDE2NiAyMDAgMTY0IDAgMTQ4IFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMDMiIGRhdGEtY2VsbC1pZD0iYzMiIGRhdGEtY29sb3ItaWQ9IjIiIGRhdGEtY29sb3ItbmFtZT0iQW1iZXIgRHJpZnQiIGRhdGEtY29sb3ItaGV4PSIjZjQ5OTRjIiBmaWxsPSIjZjQ5OTRjIj4KICAgIDx0aXRsZT5SZWdpb24gYzMg4oCTIENvbG9yICMyIChBbWJlciBEcmlmdCk8L3RpdGxlPgogICAgPHBhdGggZD0iTTAgMTQ4IEMgMTYwIDE1NiAzMjAgMTYwIDUyMCAxNTIgQyA1MDAgMTc2IDQ4MCAxOTggNDQwIDIxMiBDIDMyMCAyMjAgMTYwIDIxOCAwIDIxNiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzA0IiBkYXRhLWNlbGwtaWQ9ImM0IiBkYXRhLWNvbG9yLWlkPSIyIiBkYXRhLWNvbG9yLW5hbWU9IkFtYmVyIERyaWZ0IiBkYXRhLWNvbG9yLWhleD0iI2Y0OTk0YyIgZmlsbD0iI2Y0OTk0YyI+CiAgICA8dGl0bGU+UmVnaW9uIGM0IOKAkyBDb2xvciAjMiAoQW1iZXIgRHJpZnQpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik01MjAgMTUyIEMgNzAwIDE1MCA4NDAgMTQ2IDk2MCAxNDggQyA5NDAgMTc2IDkwMCAxOTggODYwIDIxMCBDIDc0MCAyMjAgNjQwIDIyMCA1MjAgMjE0IEMgNTIwIDE5NCA1MjAgMTcyIDUyMCAxNTIgWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMwNSIgZGF0YS1jZWxsLWlkPSJjNSIgZGF0YS1jb2xvci1pZD0iMyIgZGF0YS1jb2xvci1uYW1lPSJWaW9sZXQgUmlkZ2UiIGRhdGEtY29sb3ItaGV4PSIjOWE2YmIzIiBmaWxsPSIjOWE2YmIzIj4KICAgIDx0aXRsZT5SZWdpb24gYzUg4oCTIENvbG9yICMzIChWaW9sZXQgUmlkZ2UpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0wIDIxNiBDIDEyMCAyMjggMjIwIDIzMiAzMjAgMjMwIEMgMzAwIDI0OCAyNjAgMjY4IDIxMCAyNzggQyAxNTAgMjg2IDgwIDI4NCAwIDI4MCBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzA2IiBkYXRhLWNlbGwtaWQ9ImM2IiBkYXRhLWNvbG9yLWlkPSIzIiBkYXRhLWNvbG9yLW5hbWU9IlZpb2xldCBSaWRnZSIgZGF0YS1jb2xvci1oZXg9IiM5YTZiYjMiIGZpbGw9IiM5YTZiYjMiPgogICAgPHRpdGxlPlJlZ2lvbiBjNiDigJMgQ29sb3IgIzMgKFZpb2xldCBSaWRnZSk8L3RpdGxlPgogICAgPHBhdGggZD0iTTMyMCAyMzAgQyA0NDAgMjM2IDUyMCAyMzQgNjQwIDIyNiBDIDYzMCAyNTAgNjAwIDI2OCA1NjAgMjc2IEMgNDgwIDI4NiA0MDAgMjg0IDMyMCAyNzggQyAzMjAgMjU4IDMyMCAyNDQgMzIwIDIzMCBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzA3IiBkYXRhLWNlbGwtaWQ9ImM3IiBkYXRhLWNvbG9yLWlkPSIzIiBkYXRhLWNvbG9yLW5hbWU9IlZpb2xldCBSaWRnZSIgZGF0YS1jb2xvci1oZXg9IiM5YTZiYjMiIGZpbGw9IiM5YTZiYjMiPgogICAgPHRpdGxlPlJlZ2lvbiBjNyDigJMgQ29sb3IgIzMgKFZpb2xldCBSaWRnZSk8L3RpdGxlPgogICAgPHBhdGggZD0iTTY0MCAyMjYgQyA3NjAgMjI0IDg2MCAyMjAgOTYwIDIyMCBDIDk0MCAyNDAgOTAwIDI2MCA4NjAgMjcyIEMgNzgwIDI4NiA3MDAgMjg0IDY0MCAyNzggQyA2NDAgMjU2IDY0MCAyNDAgNjQwIDIyNiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzA4IiBkYXRhLWNlbGwtaWQ9ImM4IiBkYXRhLWNvbG9yLWlkPSI0IiBkYXRhLWNvbG9yLW5hbWU9IkZvcmVzdCBSaWRnZSIgZGF0YS1jb2xvci1oZXg9IiM1ZDdhNzYiIGZpbGw9IiM1ZDdhNzYiPgogICAgPHRpdGxlPlJlZ2lvbiBjOCDigJMgQ29sb3IgIzQgKEZvcmVzdCBSaWRnZSk8L3RpdGxlPgogICAgPHBhdGggZD0iTTAgMjgwIEMgMTAwIDI5MiAyMDAgMzAwIDMyMCAyOTIgQyAzMDAgMzEyIDI2MCAzMjggMjEwIDMzNiBDIDE1MCAzNDQgODAgMzQ0IDAgMzQwIFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMDkiIGRhdGEtY2VsbC1pZD0iYzkiIGRhdGEtY29sb3ItaWQ9IjQiIGRhdGEtY29sb3ItbmFtZT0iRm9yZXN0IFJpZGdlIiBkYXRhLWNvbG9yLWhleD0iIzVkN2E3NiIgZmlsbD0iIzVkN2E3NiI+CiAgICA8dGl0bGU+UmVnaW9uIGM5IOKAkyBDb2xvciAjNCAoRm9yZXN0IFJpZGdlKTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNMzIwIDI5MiBDIDQ0MCAyOTggNTQwIDMwMCA2NDAgMjk4IEMgNjIwIDMxOCA1ODAgMzMyIDU0MCAzNDAgQyA0NjAgMzQ4IDM4MCAzNDYgMzIwIDM0MCBDIDMyMCAzMjAgMzIwIDMwNiAzMjAgMjkyIFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMTAiIGRhdGEtY2VsbC1pZD0iYzEwIiBkYXRhLWNvbG9yLWlkPSI0IiBkYXRhLWNvbG9yLW5hbWU9IkZvcmVzdCBSaWRnZSIgZGF0YS1jb2xvci1oZXg9IiM1ZDdhNzYiIGZpbGw9IiM1ZDdhNzYiPgogICAgPHRpdGxlPlJlZ2lvbiBjMTAg4oCTIENvbG9yICM0IChGb3Jlc3QgUmlkZ2UpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik02NDAgMjk4IEMgNzYwIDMwMCA4NjAgMzAwIDk2MCAzMDAgQyA5NDAgMzIwIDkwMCAzMzIgODYwIDM0MCBDIDc4MCAzNDggNzAwIDM0OCA2NDAgMzQwIEMgNjQwIDMyMCA2NDAgMzA4IDY0MCAyOTggWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMxMSIgZGF0YS1jZWxsLWlkPSJjMTEiIGRhdGEtY29sb3ItaWQ9IjUiIGRhdGEtY29sb3ItbmFtZT0iTGFnb29uIExpZ2h0IiBkYXRhLWNvbG9yLWhleD0iIzc2YzdkNiIgZmlsbD0iIzc2YzdkNiI+CiAgICA8dGl0bGU+UmVnaW9uIGMxMSDigJMgQ29sb3IgIzUgKExhZ29vbiBMaWdodCk8L3RpdGxlPgogICAgPHBhdGggZD0iTTAgMzQwIEMgMTIwIDM0NCAyMjAgMzQ2IDMyMCAzNDQgQyAzMDAgMzUwIDMwMCAzNTIgMzIwIDM1MiBDIDIwMCAzNTYgMTIwIDM1NCAwIDM1MiBDIDAgMzQ4IDAgMzQ0IDAgMzQwIFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMTIiIGRhdGEtY2VsbC1pZD0iYzEyIiBkYXRhLWNvbG9yLWlkPSI1IiBkYXRhLWNvbG9yLW5hbWU9IkxhZ29vbiBMaWdodCIgZGF0YS1jb2xvci1oZXg9IiM3NmM3ZDYiIGZpbGw9IiM3NmM3ZDYiPgogICAgPHRpdGxlPlJlZ2lvbiBjMTIg4oCTIENvbG9yICM1IChMYWdvb24gTGlnaHQpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0zMjAgMzQ0IEMgNDQwIDM0NiA1NDAgMzQ0IDY0MCAzNDIgQyA2NDAgMzQ2IDY0MCAzNTAgNjQwIDM1MiBDIDUyMCAzNTYgNDIwIDM1NiAzMjAgMzUyIEMgMzIwIDM0OCAzMjAgMzQ2IDMyMCAzNDQgWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMxMyIgZGF0YS1jZWxsLWlkPSJjMTMiIGRhdGEtY29sb3ItaWQ9IjUiIGRhdGEtY29sb3ItbmFtZT0iTGFnb29uIExpZ2h0IiBkYXRhLWNvbG9yLWhleD0iIzc2YzdkNiIgZmlsbD0iIzc2YzdkNiI+CiAgICA8dGl0bGU+UmVnaW9uIGMxMyDigJMgQ29sb3IgIzUgKExhZ29vbiBMaWdodCk8L3RpdGxlPgogICAgPHBhdGggZD0iTTY0MCAzNDIgQyA3NjAgMzQwIDg2MCAzMzggOTYwIDM0MCBDIDk2MCAzNDQgOTYwIDM0OCA5NjAgMzUyIEMgODQwIDM1NCA3NDAgMzU0IDY0MCAzNTIgQyA2NDAgMzQ4IDY0MCAzNDQgNjQwIDM0MiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzE0IiBkYXRhLWNlbGwtaWQ9ImMxNCIgZGF0YS1jb2xvci1pZD0iNSIgZGF0YS1jb2xvci1uYW1lPSJMYWdvb24gTGlnaHQiIGRhdGEtY29sb3ItaGV4PSIjNzZjN2Q2IiBmaWxsPSIjNzZjN2Q2Ij4KICAgIDx0aXRsZT5SZWdpb24gYzE0IOKAkyBDb2xvciAjNSAoTGFnb29uIExpZ2h0KTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNMCAzNTIgQyAxMjAgMzU2IDIyMCAzNTYgMzIwIDM1MiBDIDMxMCAzNjQgMzEwIDM3MiAzMjAgMzc2IEMgMjAwIDM4MiAxMjAgMzgwIDAgMzc2IEMgMCAzNjQgMCAzNTggMCAzNTIgWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMxNSIgZGF0YS1jZWxsLWlkPSJjMTUiIGRhdGEtY29sb3ItaWQ9IjUiIGRhdGEtY29sb3ItbmFtZT0iTGFnb29uIExpZ2h0IiBkYXRhLWNvbG9yLWhleD0iIzc2YzdkNiIgZmlsbD0iIzc2YzdkNiI+CiAgICA8dGl0bGU+UmVnaW9uIGMxNSDigJMgQ29sb3IgIzUgKExhZ29vbiBMaWdodCk8L3RpdGxlPgogICAgPHBhdGggZD0iTTMyMCAzNTIgQyA0NDAgMzU0IDU0MCAzNTIgNjQwIDM1MiBDIDY1MCAzNjIgNjUwIDM3MCA2NDAgMzc2IEMgNTIwIDM4MiA0MjAgMzgyIDMyMCAzNzYgQyAzMjAgMzY2IDMyMCAzNjAgMzIwIDM1MiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzE2IiBkYXRhLWNlbGwtaWQ9ImMxNiIgZGF0YS1jb2xvci1pZD0iNSIgZGF0YS1jb2xvci1uYW1lPSJMYWdvb24gTGlnaHQiIGRhdGEtY29sb3ItaGV4PSIjNzZjN2Q2IiBmaWxsPSIjNzZjN2Q2Ij4KICAgIDx0aXRsZT5SZWdpb24gYzE2IOKAkyBDb2xvciAjNSAoTGFnb29uIExpZ2h0KTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNNjQwIDM1MiBDIDc2MCAzNTIgODYwIDM1MCA5NjAgMzUyIEMgOTYwIDM2MiA5NjAgMzcyIDk2MCAzNzYgQyA4NDAgMzgwIDc0MCAzODAgNjQwIDM3NiBDIDY0MCAzNjYgNjQwIDM1OCA2NDAgMzUyIFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMTciIGRhdGEtY2VsbC1pZD0iYzE3IiBkYXRhLWNvbG9yLWlkPSI2IiBkYXRhLWNvbG9yLW5hbWU9IkxhZ29vbiBEZXB0aCIgZGF0YS1jb2xvci1oZXg9IiMxYzZmOGMiIGZpbGw9IiMxYzZmOGMiPgogICAgPHRpdGxlPlJlZ2lvbiBjMTcg4oCTIENvbG9yICM2IChMYWdvb24gRGVwdGgpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0wIDM3NiBDIDE2MCAzODIgMzIwIDM4OCA0ODAgMzg0IEMgNDgwIDM5NCA0ODAgNDAwIDQ4MCA0MDQgQyAzMjAgNDA4IDE2MCA0MDQgMCA0MDQgQyAwIDM5MiAwIDM4NCAwIDM3NiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzE4IiBkYXRhLWNlbGwtaWQ9ImMxOCIgZGF0YS1jb2xvci1pZD0iNiIgZGF0YS1jb2xvci1uYW1lPSJMYWdvb24gRGVwdGgiIGRhdGEtY29sb3ItaGV4PSIjMWM2ZjhjIiBmaWxsPSIjMWM2ZjhjIj4KICAgIDx0aXRsZT5SZWdpb24gYzE4IOKAkyBDb2xvciAjNiAoTGFnb29uIERlcHRoKTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNNDgwIDM3NiBDIDY0MCAzODIgODAwIDM4MCA5NjAgMzc2IEw5NjAgNDA0IEMgODAwIDQxMCA2NDAgNDEyIDQ4MCA0MDQgQyA0ODAgMzk0IDQ4MCAzODYgNDgwIDM3NiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzE5IiBkYXRhLWNlbGwtaWQ9ImMxOSIgZGF0YS1jb2xvci1pZD0iNiIgZGF0YS1jb2xvci1uYW1lPSJMYWdvb24gRGVwdGgiIGRhdGEtY29sb3ItaGV4PSIjMWM2ZjhjIiBmaWxsPSIjMWM2ZjhjIj4KICAgIDx0aXRsZT5SZWdpb24gYzE5IOKAkyBDb2xvciAjNiAoTGFnb29uIERlcHRoKTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNMCA0MDQgQyAxNjAgNDEwIDMyMCA0MTYgNDgwIDQxMiBDIDQ4MCA0MjggNDgwIDQ0MCA0ODAgNDQ4IEMgMzIwIDQ1NiAxNjAgNDUyIDAgNDQ4IEMgMCA0MzAgMCA0MTYgMCA0MDQgWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMyMCIgZGF0YS1jZWxsLWlkPSJjMjAiIGRhdGEtY29sb3ItaWQ9IjYiIGRhdGEtY29sb3ItbmFtZT0iTGFnb29uIERlcHRoIiBkYXRhLWNvbG9yLWhleD0iIzFjNmY4YyIgZmlsbD0iIzFjNmY4YyI+CiAgICA8dGl0bGU+UmVnaW9uIGMyMCDigJMgQ29sb3IgIzYgKExhZ29vbiBEZXB0aCk8L3RpdGxlPgogICAgPHBhdGggZD0iTTQ4MCA0MTIgQyA2NDAgNDE2IDgwMCA0MTAgOTYwIDQwNCBMOTYwIDQ0OCBDIDgyMCA0NTYgNjgwIDQ2MCA1MjAgNDU2IEMgNTAwIDQ1NCA0OTAgNDQ4IDQ4MCA0NDggQyA0ODAgNDMyIDQ4MCA0MjAgNDgwIDQxMiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzIxIiBkYXRhLWNlbGwtaWQ9ImMyMSIgZGF0YS1jb2xvci1pZD0iNyIgZGF0YS1jb2xvci1uYW1lPSJTaG9yZSBMZWZ0IiBkYXRhLWNvbG9yLWhleD0iIzRmN2Q1YyIgZmlsbD0iIzRmN2Q1YyI+CiAgICA8dGl0bGU+UmVnaW9uIGMyMSDigJMgQ29sb3IgIzcgKFNob3JlIExlZnQpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik0wIDQ0OCBDIDEyMCA0NTQgMjIwIDQ1OCAzMDAgNDYyIEMgMjgwIDUwMCAyMjAgNTQwIDE0MCA1NjYgQyA4MCA1ODQgMzAgNTkyIDAgNTkyIEMgMCA1NDQgMCA0OTYgMCA0NDggWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMyMiIgZGF0YS1jZWxsLWlkPSJjMjIiIGRhdGEtY29sb3ItaWQ9IjciIGRhdGEtY29sb3ItbmFtZT0iU2hvcmUgTGVmdCIgZGF0YS1jb2xvci1oZXg9IiM0ZjdkNWMiIGZpbGw9IiM0ZjdkNWMiPgogICAgPHRpdGxlPlJlZ2lvbiBjMjIg4oCTIENvbG9yICM3IChTaG9yZSBMZWZ0KTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNMzAwIDQ2MiBDIDM2MCA0NjggNDIwIDQ3MiA1MjAgNDU2IEMgNTEwIDQ4NiA0OTAgNTE0IDQ2MCA1NDAgQyA0MjAgNTY4IDM2MCA1ODAgMzAwIDU3MiBDIDI4MCA1NDAgMjkwIDUwMCAzMDAgNDYyIFoiLz4KICA8L2c+CiAgPGcgaWQ9InJlZ2lvbi1jMjMiIGRhdGEtY2VsbC1pZD0iYzIzIiBkYXRhLWNvbG9yLWlkPSI4IiBkYXRhLWNvbG9yLW5hbWU9IlNob3JlIE1pZGRsZSIgZGF0YS1jb2xvci1oZXg9IiM2YjkzNTgiIGZpbGw9IiM2YjkzNTgiPgogICAgPHRpdGxlPlJlZ2lvbiBjMjMg4oCTIENvbG9yICM4IChTaG9yZSBNaWRkbGUpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik01MjAgNDU2IEMgNjQwIDQ2MiA3MjAgNDY0IDc4MCA0NjAgQyA3ODggNDc0IDc5MiA0OTggNzk2IDUyOCBDIDc4NiA1ODAgNzY4IDU4NCA3NTIgNTg4IEMgNzAwIDYwMCA2NTYgNTk4IDYwNCA1ODggQyA1NjYgNTgwIDUzNCA1NjQgNTE4IDU0NiBDIDUwNiA1MzIgNTA2IDUyMCA1MjAgNTEwIEMgNTA4IDQ5NiA1MTIgNDc2IDUyMCA0NTYgWiIvPgogIDwvZz4KICA8ZyBpZD0icmVnaW9uLWMyNCIgZGF0YS1jZWxsLWlkPSJjMjQiIGRhdGEtY29sb3ItaWQ9IjkiIGRhdGEtY29sb3ItbmFtZT0iQ2FweSBCb2R5IiBkYXRhLWNvbG9yLWhleD0iIzdkNTczNSIgZmlsbD0iIzdkNTczNSI+CiAgICA8dGl0bGU+UmVnaW9uIGMyNCDigJMgQ29sb3IgIzkgKENhcHkgQm9keSk8L3RpdGxlPgogICAgPHBhdGggZD0iTTUyMCA1MTAgQyA1NDggNDcwIDYxMiA0NDAgNjkyIDQzNCBDIDc0NCA0MzAgNzY4IDQzOCA3ODAgNDU2IEMgNzkwIDQ3NCA3OTQgNDk4IDc5NiA1MjggQyA3OTggNTU2IDc4NiA1ODAgNzUyIDU4OCBDIDcwOCA2MDAgNjU2IDU5OCA2MDQgNTg4IEMgNTY2IDU4MCA1MzQgNTY0IDUxOCA1NDYgQyA1MDggNTMyIDUwNiA1MTggNTIwIDUxMCBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzI1IiBkYXRhLWNlbGwtaWQ9ImMyNSIgZGF0YS1jb2xvci1pZD0iMTAiIGRhdGEtY29sb3ItbmFtZT0iQ2FweSBIZWFkIiBkYXRhLWNvbG9yLWhleD0iIzVlM2IyNCIgZmlsbD0iIzVlM2IyNCI+CiAgICA8dGl0bGU+UmVnaW9uIGMyNSDigJMgQ29sb3IgIzEwIChDYXB5IEhlYWQpPC90aXRsZT4KICAgIDxwYXRoIGQ9Ik03ODAgNDU2IEMgODA0IDQzOCA4MzggNDM4IDg2NiA0NjAgQyA4OTQgNDgyIDkwNCA1MjAgODkyIDU1NiBDIDg3OCA1OTQgODQ2IDYwOCA4MTAgNjAwIEMgODAwIDU5OCA3OTYgNTkwIDc5NiA1MjggQyA3OTQgNTAwIDc4OCA0NzQgNzgwIDQ1NiBaIi8+CiAgPC9nPgogIDxnIGlkPSJyZWdpb24tYzI2IiBkYXRhLWNlbGwtaWQ9ImMyNiIgZGF0YS1jb2xvci1pZD0iMTEiIGRhdGEtY29sb3ItbmFtZT0iU2hvcmUgUmlnaHQiIGRhdGEtY29sb3ItaGV4PSIjM2Y1YjNiIiBmaWxsPSIjM2Y1YjNiIj4KICAgIDx0aXRsZT5SZWdpb24gYzI2IOKAkyBDb2xvciAjMTEgKFNob3JlIFJpZ2h0KTwvdGl0bGU+CiAgICA8cGF0aCBkPSJNNzgwIDQ2MCBDIDg0MCA0NTYgOTAwIDQ1NCA5NjAgNDUyIEw5NjAgNjAwIEMgOTEwIDYwMCA4NzAgNTk4IDgxMCA2MDAgQyA4NDYgNjA4IDg3OCA1OTQgODkyIDU1NiBDIDg4NCA1MjAgODYwIDQ4OCA3ODAgNDYwIFoiLz4KICA8L2c+Cjwvc3ZnPgo=",
       };
 
+      const SAMPLE_DETAIL_LEVELS = {
+        low: {
+          id: "low",
+          label: "Low detail",
+          shortLabel: "Low",
+          summary: "Low detail • 18 colours / 15 px² min regions / 1216 px resize • ≈26 regions",
+          ariaLabel:
+            "Low detail – 18 colours, 15 pixel minimum regions, 1216px resize target, about 26 regions",
+          logDescriptor: "low detail",
+          approxRegions: 26,
+          settings: {
+            targetColors: 18,
+            minRegion: 15,
+            maxSize: 1216,
+            sampleRate: 90,
+            kmeansIters: 20,
+            smoothingPasses: 1,
+          },
+        },
+        medium: {
+          id: "medium",
+          label: "Medium detail",
+          shortLabel: "Medium",
+          summary: "Medium detail • 26 colours / 8 px² min regions / 1408 px resize • ≈42 regions",
+          ariaLabel:
+            "Medium detail – 26 colours, 8 pixel minimum regions, 1408px resize target, about 42 regions",
+          logDescriptor: "medium detail",
+          approxRegions: 42,
+          settings: {
+            targetColors: 26,
+            minRegion: 8,
+            maxSize: 1408,
+            sampleRate: 95,
+            kmeansIters: 24,
+            smoothingPasses: 1,
+          },
+        },
+        high: {
+          id: "high",
+          label: "High detail",
+          shortLabel: "High",
+          summary: "High detail • 32 colours / 3 px² min regions / 1536 px resize • ≈140 regions",
+          ariaLabel:
+            "High detail – 32 colours, 3 pixel minimum regions, 1536px resize target, about 140 regions",
+          logDescriptor: "high detail",
+          approxRegions: 140,
+          settings: {
+            targetColors: 32,
+            minRegion: 3,
+            maxSize: 1536,
+            sampleRate: 100,
+            kmeansIters: 28,
+            smoothingPasses: 1,
+          },
+        },
+      };
+      const DEFAULT_SAMPLE_DETAIL = "high";
+
+      
       if (samplePreview) {
         samplePreview.src = SAMPLE_ARTWORK.dataUrl;
         samplePreview.alt = SAMPLE_ARTWORK.description;
@@ -1165,10 +1470,13 @@
         sourceUrl: null,
         sourceTitle: null,
         lastOptions: null,
+        sampleDetailLevel: DEFAULT_SAMPLE_DETAIL,
         settings: {
           autoAdvance: true,
           animateHints: true,
           backgroundColor: DEFAULT_BACKGROUND_HEX,
+          uiScale: 1,
+          artPrompt: "",
         },
         previewVisible: false,
         saves: loadSavedEntries(),
@@ -1190,12 +1498,19 @@
             hintFlashToggle.checked = settings.animateHints;
           }
         }
+        if (typeof settings.uiScale === "number") {
+          applyUiScale(settings.uiScale, { skipLog: true, skipAutosave: true });
+        }
+        if (typeof settings.artPrompt === "string") {
+          applyArtPrompt(settings.artPrompt, { skipLog: true, skipAutosave: true });
+        }
       }
 
       const debugLogEntries = [];
       const DEBUG_LOG_LIMIT = 80;
 
       if (typeof window !== "undefined") {
+        installBrowserZoomGuards();
         // Public hooks for tests and manual loading. Keep backwards compatible.
         window.capyGenerator = {
           getState: () => state,
@@ -1224,6 +1539,15 @@
           setBackgroundColor(hex) {
             applyBackgroundColor(hex);
           },
+          setUiScale(scale) {
+            applyUiScale(scale);
+          },
+          setArtPrompt(promptText) {
+            applyArtPrompt(promptText);
+          },
+          isBrowserZoomSuppressed() {
+            return preventingBrowserZoom;
+          },
           togglePreview(show) {
             if (typeof show === "boolean") {
               state.previewVisible = show;
@@ -1247,14 +1571,27 @@
 
       for (const button of sampleButtons) {
         if (!button) continue;
+        button.setAttribute("type", "button");
         button.title = `Play ${SAMPLE_ARTWORK.title}`;
         button.addEventListener("click", () => {
-          loadSamplePuzzle();
+          loadSamplePuzzle({ detailLevel: state.sampleDetailLevel });
         });
       }
 
-      if (!loadInitialSession() && SAMPLE_ARTWORK?.dataUrl) {
-        loadSamplePuzzle();
+      for (const button of sampleDetailButtons) {
+        if (!button) continue;
+        button.setAttribute("type", "button");
+        button.addEventListener("click", (event) => {
+          const target = event?.currentTarget?.dataset?.detailLevel;
+          applySampleDetailLevel(target);
+        });
+      }
+
+      applySampleDetailLevel(DEFAULT_SAMPLE_DETAIL, { skipReload: true, skipLog: true });
+
+      const restoredSession = loadInitialSession();
+      if (!restoredSession && SAMPLE_ARTWORK?.dataUrl) {
+        loadSamplePuzzle({ detailLevel: state.sampleDetailLevel, skipDetailUpdate: true });
       }
 
       selectButton.addEventListener("click", () => fileInput.click());
@@ -1329,11 +1666,28 @@
 
       if (backgroundColorInput) {
         backgroundColorInput.addEventListener("input", (event) => {
-          applyBackgroundColor(event.target.value, { skipLog: true });
+          applyBackgroundColor(event.target.value, { skipLog: true, skipAutosave: true });
         });
         backgroundColorInput.addEventListener("change", (event) => {
           applyBackgroundColor(event.target.value);
-          scheduleAutosave("background-colour");
+        });
+      }
+
+      if (uiScaleInput) {
+        uiScaleInput.addEventListener("input", (event) => {
+          applyUiScale(event.target.value, { skipLog: true, skipAutosave: true });
+        });
+        uiScaleInput.addEventListener("change", (event) => {
+          applyUiScale(event.target.value);
+        });
+      }
+
+      if (artPromptInput) {
+        artPromptInput.addEventListener("input", (event) => {
+          applyArtPrompt(event.target.value, { skipLog: true, skipAutosave: true });
+        });
+        artPromptInput.addEventListener("change", (event) => {
+          applyArtPrompt(event.target.value);
         });
       }
 
@@ -1689,18 +2043,107 @@
         }
       }
 
+      function applySampleDetailLevel(level, options = {}) {
+        const { skipReload = false, skipLog = false, skipOptions = false } = options;
+        const normalized = level && SAMPLE_DETAIL_LEVELS[level] ? level : DEFAULT_SAMPLE_DETAIL;
+        const config = SAMPLE_DETAIL_LEVELS[normalized];
+        if (!config) return null;
+        const previousLevel = state.sampleDetailLevel;
+        state.sampleDetailLevel = config.id;
+        for (const button of sampleDetailButtons) {
+          if (!button) continue;
+          const targetLevel = button.dataset.detailLevel;
+          const targetConfig = SAMPLE_DETAIL_LEVELS[targetLevel];
+          if (targetConfig) {
+            button.textContent = targetConfig.shortLabel;
+            button.setAttribute("aria-label", targetConfig.ariaLabel);
+            button.title = targetConfig.ariaLabel;
+          }
+          const isActive = targetLevel === config.id;
+          button.setAttribute("aria-pressed", isActive ? "true" : "false");
+        }
+        for (const caption of sampleDetailCaptions) {
+          if (caption) {
+            caption.textContent = config.summary;
+          }
+        }
+        for (const button of sampleButtons) {
+          if (!button) continue;
+          const labelBase = `Reload ${SAMPLE_ARTWORK.title}`;
+          const detailSummary = config.summary || config.label;
+          const titleText = detailSummary ? `${labelBase} – ${detailSummary}` : `${labelBase} – ${config.label}`;
+          const ariaText = detailSummary ? `${labelBase} (${detailSummary})` : `${labelBase} (${config.label})`;
+          button.title = titleText;
+          button.setAttribute("aria-label", ariaText);
+          if (config.approxRegions != null) {
+            button.dataset.detailRegions = String(config.approxRegions);
+          }
+        }
+        if (samplePreview) {
+          const previewSummary = config.summary || config.label;
+          samplePreview.title = previewSummary
+            ? `${SAMPLE_ARTWORK.title} – ${previewSummary}`
+            : `${SAMPLE_ARTWORK.title} – ${config.label}`;
+          if (config.approxRegions != null) {
+            samplePreview.dataset.detailRegions = String(config.approxRegions);
+          }
+        }
+        if (!skipOptions) {
+          const settings = config.settings || {};
+          if (colorCountEl && typeof settings.targetColors === "number") {
+            colorCountEl.value = String(settings.targetColors);
+          }
+          if (minRegionEl && typeof settings.minRegion === "number") {
+            minRegionEl.value = String(settings.minRegion);
+          }
+          if (detailEl && typeof settings.maxSize === "number") {
+            detailEl.value = String(settings.maxSize);
+          }
+          if (sampleRateEl && typeof settings.sampleRate === "number") {
+            sampleRateEl.value = String(settings.sampleRate);
+          }
+          if (kmeansItersEl && typeof settings.kmeansIters === "number") {
+            kmeansItersEl.value = String(settings.kmeansIters);
+          }
+          if (smoothingEl && typeof settings.smoothingPasses === "number") {
+            smoothingEl.value = String(settings.smoothingPasses);
+          }
+          updateOptionOutputs();
+          markOptionsDirty();
+        }
+        if (!skipLog && previousLevel !== config.id) {
+          logDebug(`Sample detail set to ${config.label} – ${config.summary}`);
+        }
+        if (!skipReload && state.sourceUrl === SAMPLE_ARTWORK.dataUrl) {
+          loadSamplePuzzle({ detailLevel: config.id, skipDetailUpdate: true });
+        }
+        return config;
+      }
+
       function loadSamplePuzzle(options = {}) {
-        const { announce = true } = options;
+        const { announce = true, detailLevel, skipDetailUpdate = false } = options;
         const { dataUrl } = SAMPLE_ARTWORK;
         if (!dataUrl) return;
+        const targetLevel = detailLevel || state.sampleDetailLevel || DEFAULT_SAMPLE_DETAIL;
+        const detailConfig = skipDetailUpdate
+          ? SAMPLE_DETAIL_LEVELS[targetLevel] || SAMPLE_DETAIL_LEVELS[DEFAULT_SAMPLE_DETAIL]
+          : applySampleDetailLevel(targetLevel, { skipReload: true, skipLog: !announce }) ||
+            SAMPLE_DETAIL_LEVELS[targetLevel] ||
+            SAMPLE_DETAIL_LEVELS[DEFAULT_SAMPLE_DETAIL];
         resetPuzzleUI();
         state.sourceUrl = dataUrl;
         state.sourceTitle = SAMPLE_ARTWORK.title || "Sample puzzle";
         startHint.classList.add("hidden");
+        const label = detailConfig ? detailConfig.label : null;
+        const logDescriptor = detailConfig?.logDescriptor || (label ? label.toLowerCase() : null);
         const loadOptions = announce
           ? {
-              logMessage: `Loading sample puzzle: ${state.sourceTitle}`,
-              completionMessage: `Loading sample puzzle complete: ${state.sourceTitle}`,
+              logMessage: logDescriptor
+                ? `Loading ${logDescriptor} sample puzzle: ${state.sourceTitle}`
+                : `Loading sample puzzle: ${state.sourceTitle}`,
+              completionMessage: label
+                ? `${label} sample puzzle ready: ${state.sourceTitle}`
+                : `Loading sample puzzle complete: ${state.sourceTitle}`,
               skipDefaultLog: true,
             }
           : undefined;
@@ -1765,6 +2208,47 @@
         renderDebugLog();
       }
 
+      function applyUiScale(scale, options = {}) {
+        const { skipLog = false, skipAutosave = false, force = false } = options;
+        const numeric = Number(scale);
+        const resolved = clamp(Number.isFinite(numeric) ? numeric : state.settings.uiScale || 1, 0.8, 1.35);
+        const current = state.settings.uiScale ?? 1;
+        const changed = force || Math.abs(resolved - current) > 0.001;
+        state.settings.uiScale = resolved;
+        document.documentElement.style.setProperty("--ui-scale", String(resolved));
+        if (uiScaleInput && Math.abs(Number(uiScaleInput.value) - resolved) > 0.001) {
+          uiScaleInput.value = String(resolved);
+        }
+        updateOptionOutputs();
+        if (changed && !skipLog) {
+          logDebug(`Interface scale set to ${Math.round(resolved * 100)}%`);
+        }
+        if (changed && !skipAutosave) {
+          scheduleAutosave("settings-ui-scale");
+        }
+        return resolved;
+      }
+
+      function applyArtPrompt(text, options = {}) {
+        const { skipLog = false, skipAutosave = false } = options;
+        const normalized = typeof text === "string" ? text : "";
+        const previous = state.settings.artPrompt ?? "";
+        state.settings.artPrompt = normalized;
+        if (artPromptInput && artPromptInput.value !== normalized) {
+          artPromptInput.value = normalized;
+        }
+        if (normalized !== previous) {
+          if (!skipLog) {
+            const trimmed = normalized.trim();
+            logDebug(trimmed ? `Art prompt updated (${trimmed.length} characters)` : "Art prompt cleared");
+          }
+          if (!skipAutosave) {
+            scheduleAutosave("settings-art-prompt");
+          }
+        }
+        return normalized;
+      }
+
       function applyBackgroundColor(hex, options = {}) {
         const { skipRender = false, skipLog = false, force = false } = options;
         const current = state.settings.backgroundColor ?? DEFAULT_BACKGROUND_HEX;
@@ -1793,6 +2277,9 @@
         if (changed && !skipLog) {
           logDebug(`Background colour set to ${normalized.toUpperCase()}`);
         }
+        if (changed && !options.skipAutosave) {
+          scheduleAutosave("background-colour");
+        }
         return normalized;
       }
 
@@ -1803,6 +2290,11 @@
         if (optionOutputs.sample) optionOutputs.sample.textContent = `${sampleRateEl.value}%`;
         if (optionOutputs.iterations) optionOutputs.iterations.textContent = String(kmeansItersEl.value);
         if (optionOutputs.smoothing) optionOutputs.smoothing.textContent = String(smoothingEl.value);
+        if (optionOutputs.uiScale) {
+          const source = uiScaleInput ? parseFloat(uiScaleInput.value) : NaN;
+          const value = Number.isFinite(source) ? source : state.settings.uiScale || 1;
+          optionOutputs.uiScale.textContent = `${Math.round(value * 100)}%`;
+        }
       }
 
       function markOptionsDirty() {
@@ -2005,10 +2497,35 @@
           console.error("Puzzle data missing palette information.");
           return false;
         }
-        const mapSource = Array.from(data.regionMap ?? []);
-        if (mapSource.length !== data.width * data.height) {
+        const expectedCells = data.width * data.height;
+        const regionMapSource =
+          unpackRegionMap(data.regionMapPacked, expectedCells) ||
+          unpackRegionMap(data.regionMap, expectedCells);
+        if (!regionMapSource || regionMapSource.length !== expectedCells) {
           console.error("Puzzle data is inconsistent.");
           return false;
+        }
+        let needsPixelHydration = false;
+        for (const region of data.regions) {
+          if (!Array.isArray(region.pixels) || region.pixels.length === 0) {
+            needsPixelHydration = true;
+            break;
+          }
+        }
+        let hydratedPixels = null;
+        if (needsPixelHydration) {
+          hydratedPixels = new Map();
+          for (let i = 0; i < data.regions.length; i++) {
+            const region = data.regions[i];
+            const resolvedId = region.id != null ? region.id : i;
+            hydratedPixels.set(resolvedId, []);
+          }
+          for (let idx = 0; idx < regionMapSource.length; idx++) {
+            const regionId = regionMapSource[idx];
+            if (hydratedPixels.has(regionId)) {
+              hydratedPixels.get(regionId).push(idx);
+            }
+          }
         }
         const palette = data.palette.map((entry, index) => {
           const hex = entry.hex ?? "#ffffff";
@@ -2031,7 +2548,12 @@
           };
         });
         const regions = data.regions.map((region, index) => {
-          const pixels = Array.from(region.pixels ?? []);
+          const resolvedId = region.id != null ? region.id : index;
+          const pixelsSource =
+            Array.isArray(region.pixels) && region.pixels.length > 0
+              ? region.pixels
+              : hydratedPixels?.get(resolvedId) || [];
+          const pixels = Array.from(pixelsSource);
           const pixelCount = region.pixelCount ?? pixels.length;
           let cx = typeof region.cx === "number" ? region.cx : null;
           let cy = typeof region.cy === "number" ? region.cy : null;
@@ -2046,7 +2568,7 @@
             cy = sumY / pixels.length;
           }
           return {
-            id: region.id ?? index,
+            id: resolvedId,
             colorId: region.colorId ?? 1,
             pixels,
             pixelCount,
@@ -2054,7 +2576,9 @@
             cy: cy ?? 0,
           };
         });
-        const regionMap = new Int32Array(mapSource);
+        const regionMap = regionMapSource instanceof Int32Array
+          ? regionMapSource
+          : new Int32Array(regionMapSource);
         const metadataTitle =
           typeof metadata.title === "string" && metadata.title.trim() ? metadata.title.trim() : null;
         const completionLog =
@@ -2666,20 +3190,27 @@
       }
 
       function restoreViewport(viewport = {}) {
-        if (!state.puzzle || !viewport || typeof viewport !== "object") {
-          return false;
-        }
+        if (!state.puzzle) return false;
+        if (!viewport || typeof viewport !== "object") return false;
+        const hasZoom = typeof viewport.zoom === "number";
+        const hasBase = typeof viewport.baseScale === "number";
+        const hasPanX = typeof viewport.panX === "number";
+        const hasPanY = typeof viewport.panY === "number";
+        if (!hasZoom && !hasBase && !hasPanX && !hasPanY) return false;
         const nextBase = computeFitScale();
-        const savedBase = Number.isFinite(viewport.baseScale) ? viewport.baseScale : nextBase;
-        const scaleRatio = savedBase && Number.isFinite(savedBase) ? nextBase / savedBase : 1;
-        const savedZoom = Number.isFinite(viewport.zoom) ? viewport.zoom : 1;
-        const targetZoom = savedBase && Number.isFinite(savedBase)
-          ? (savedBase * savedZoom) / (nextBase || savedBase)
-          : savedZoom;
+        const savedBase = hasBase && Number.isFinite(viewport.baseScale) && viewport.baseScale > 0
+          ? viewport.baseScale
+          : nextBase;
+        const scaleRatio =
+          savedBase && Number.isFinite(savedBase) && nextBase > 0 ? nextBase / savedBase : 1;
+        const savedZoom = hasZoom && Number.isFinite(viewport.zoom) && viewport.zoom > 0
+          ? viewport.zoom
+          : 1;
+        const targetZoom = Number.isFinite(scaleRatio) && scaleRatio > 0 ? savedZoom * scaleRatio : savedZoom;
         viewState.baseScale = nextBase;
-        viewState.zoom = clamp(targetZoom, 0.05, 16);
-        viewState.panX = Number.isFinite(viewport.panX) ? viewport.panX * scaleRatio : 0;
-        viewState.panY = Number.isFinite(viewport.panY) ? viewport.panY * scaleRatio : 0;
+        viewState.zoom = clamp(targetZoom, 0.2, 6);
+        viewState.panX = hasPanX && Number.isFinite(viewport.panX) ? viewport.panX * scaleRatio : 0;
+        viewState.panY = hasPanY && Number.isFinite(viewport.panY) ? viewport.panY * scaleRatio : 0;
         applyViewTransform();
         return true;
       }
@@ -2778,7 +3309,9 @@
 
       function serializeCurrentPuzzle() {
         if (!state.puzzle) return {};
-        return {
+        const regionMapPacked = packRegionMap(state.puzzle.regionMap);
+        const payload = {
+          format: "capy-puzzle@2",
           title: state.sourceTitle || "capy-puzzle",
           width: state.puzzle.width,
           height: state.puzzle.height,
@@ -2791,12 +3324,10 @@
           regions: state.puzzle.regions.map((region) => ({
             id: region.id,
             colorId: region.colorId,
-            pixels: Array.from(region.pixels ?? []),
             pixelCount: region.pixelCount,
             cx: region.cx,
             cy: region.cy,
           })),
-          regionMap: Array.from(state.puzzle.regionMap),
           filled: Array.from(state.filled),
           options: state.lastOptions,
           sourceUrl: state.sourceUrl,
@@ -2811,8 +3342,16 @@
           settings: {
             autoAdvance: Boolean(state.settings.autoAdvance),
             animateHints: Boolean(state.settings.animateHints),
+            uiScale: Number(state.settings.uiScale) || 1,
+            artPrompt: state.settings.artPrompt || "",
           },
         };
+        if (regionMapPacked) {
+          payload.regionMapPacked = regionMapPacked;
+        } else if (state.puzzle.regionMap) {
+          payload.regionMap = Array.from(state.puzzle.regionMap);
+        }
+        return payload;
       }
 
       function scheduleAutosave(reason, options = {}) {
@@ -2855,8 +3394,13 @@
           localStorage.setItem(AUTOSAVE_STORAGE_KEY, JSON.stringify(record));
         } catch (error) {
           console.error("Failed to persist autosave", error);
+          if (error && error.name === "QuotaExceededError") {
+            logDebug("Storage full: unable to write autosave. Delete old saves or exports and retry.");
+          }
         }
-        cloudSync.persist(record);
+        if (cloudSync && typeof cloudSync.persist === "function") {
+          cloudSync.persist(record);
+        }
         return record;
       }
 
@@ -2880,7 +3424,9 @@
         if (autosave && autosave.data) {
           candidates.push({ ...autosave, origin: "local autosave" });
         }
-        const cloudRecord = cloudSync.getSnapshot ? cloudSync.getSnapshot() : null;
+        const cloudRecord = cloudSync && typeof cloudSync.getSnapshot === "function"
+          ? cloudSync.getSnapshot()
+          : null;
         if (cloudRecord && cloudRecord.data) {
           candidates.push({ ...cloudRecord, origin: "cloud backup" });
         }
@@ -2930,6 +3476,69 @@
           }
         }
         return false;
+      }
+
+      function packRegionMap(map) {
+        if (!map || typeof map.length !== "number") return null;
+        try {
+          const typed =
+            map instanceof Int32Array
+              ? new Int32Array(map)
+              : map instanceof Uint32Array
+              ? new Int32Array(map)
+              : new Int32Array(Array.from(map));
+          const bytes = new Uint8Array(typed.buffer);
+          let binary = "";
+          for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+          }
+          return btoa(binary);
+        } catch (error) {
+          console.error("Failed to pack region map", error);
+          return null;
+        }
+      }
+
+      function unpackRegionMap(source, expectedLength) {
+        if (!source) return null;
+        try {
+          if (typeof source === "string") {
+            const binary = atob(source);
+            const buffer = new ArrayBuffer(binary.length);
+            const bytes = new Uint8Array(buffer);
+            for (let i = 0; i < binary.length; i++) {
+              bytes[i] = binary.charCodeAt(i);
+            }
+            if (typeof expectedLength === "number" && buffer.byteLength / 4 !== expectedLength) {
+              return null;
+            }
+            return new Int32Array(buffer);
+          }
+          if (source instanceof Int32Array) {
+            if (typeof expectedLength === "number" && source.length !== expectedLength) {
+              return null;
+            }
+            return new Int32Array(source);
+          }
+          if (source instanceof Uint32Array) {
+            const copy = new Int32Array(source);
+            if (typeof expectedLength === "number" && copy.length !== expectedLength) {
+              return null;
+            }
+            return copy;
+          }
+          if (Array.isArray(source) || ArrayBuffer.isView(source)) {
+            const array = Array.isArray(source) ? source : Array.from(source);
+            if (typeof expectedLength === "number" && array.length !== expectedLength) {
+              return null;
+            }
+            return new Int32Array(array);
+          }
+        } catch (error) {
+          console.error("Failed to unpack region map", error);
+          return null;
+        }
+        return null;
       }
 
       function createCloudSync() {
@@ -3106,6 +3715,9 @@
           localStorage.setItem(SAVE_STORAGE_KEY, JSON.stringify(state.saves));
         } catch (error) {
           console.error("Failed to persist saves", error);
+          if (error && error.name === "QuotaExceededError") {
+            logDebug("Storage full: unable to write save snapshot. Delete old saves or exports and retry.");
+          }
         }
       }
 

--- a/ui-review.md
+++ b/ui-review.md
@@ -7,12 +7,17 @@
 - A dedicated interaction check clicks the first paintable region, ensuring the DOM reflects the filled state and no console errors appear while tapping-to-fill.
 - Interaction coverage also asserts that selecting a palette swatch pulses every matching region and that mouse-wheel as well as keyboard `+`/`-` zoom controls adjust the viewport scale.
 - The smoke run now expects the bundled sample puzzle to be ready on load and confirms the fullscreen control is available for edge-to-edge play.
+- The auto-load sweep now toggles the Low/Medium/High detail chips to confirm the generator sliders, palette size, and debug log entries react to each preset.
+- The first pass also verifies that the art prompt textarea remains hidden until the Settings sheet's Advanced options summary is expanded, so the query stays tucked away from casual play while we confirm it renders correctly when requested.
+- Initial assertions now confirm the viewport meta disables browser zoom and the runtime exposes an active double-tap guard so handheld sessions stay focused on the custom pan/zoom handlers.
 - Review the generated JSON for console errors and metadata counts, then open the screenshot to confirm composition changes look right before merging.
 
 ## Positive Observations
 - The Peek control lets you preview the finished painting without leaving the canvas, either by holding or toggling the button.
-- The bundled capybara sample now appears automatically on load and showcases the detailed "Capybara Springs" lagoon scene, so testers can start painting without importing external art.
+- The bundled capybara sample now appears automatically on load in the high-detail preset and showcases the detailed "Capybara Springs" lagoon scene, so testers can start painting without importing external art.
+- The onboarding hint and Settings sheet now share Low/Medium/High detail chips with a running summary that calls out the ≈26/≈42/≈140-region presets, so QA can swap between breezy and high-fidelity palettes without touching raw sliders.
 - Palette swatches now tuck their color names directly inside the button while keeping the numbers bold, so picking the next hue is faster without extra labels.
+- Rolling autosaves restore the latest session on refresh and mirror through the cloud sync hook, so QA can reload mid-play and keep their progress in step across tabs.
 - Tap-to-fill now fires on deliberate taps, and palette swatches respect the same pointer handling so choosing a color on touch devices never requires a second press while drag gestures stay focused on panning.
 - Left-drag panning now keeps the canvas full-screen while the palette hugs the bottom edge without a frame.
 - The Help & shortcuts sheet now lists every command icon, reiterates the gesture cheatsheet, and pipes a live debug log so QA can confirm fills, hints, zooms, and the start/finish of sample reloads as they happen.
@@ -23,6 +28,7 @@
 - Mousewheel zoom now stays anchored under the cursor, eases smoothly toward the target scale, keyboard nudges on `+`/`-` mirror the motion, and both mouse buttons pan the scene, so navigation feels immediate and predictable.
 - Palette pulses now accompany colour selection so playtesters immediately see every matching region (or a brief celebration when a colour is finished).
 - The Settings sheet now exposes a background colour picker that immediately repaints unfinished regions and recalibrates outline contrast, making dark themes workable without extra CSS overrides.
+- The Appearance section now layers in an interface scale slider so QA can enlarge or shrink the command rail and palette without altering puzzle zoom, and the Advanced options accordion hides the art prompt query until it's explicitly expanded for metadata editing.
 - Long-pressing the hint icon now peeks at the finished artwork while a tap still flashes hint pulses, so advanced guidance stays one gesture away.
 - Slimmed palette bubbles still feel tactile thanks to the inset numbering and glow, and they give the composition more breathing room around the artwork.
 - Region numerals now stay centered even inside narrow tree trunks or tapered highlights, which makes the puzzle feel more intentional when zoomed in.


### PR DESCRIPTION
## Summary
- add capybara sample detail presets, interface scale controls, and a mobile zoom guard alongside a refreshed segmented SVG asset
- update documentation with preset guidance, gameplay notes, and a detailed capybara region map
- extend the Playwright suite to exercise the new detail presets, zoom guard, and interface scale handling

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e44440774c8331910b0119077562b2