### PR TITLE
Improve viewport sizing and zoom handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ tools, a save manager, and a configurable generator all live inside a single
   trigger browser-level zoom; a global guard redirects them to the custom
   canvas handlers so the HUD stays stable while pan/zoom gestures still feel
   natural on touchscreens.
+- **Responsive command rail.** Header icons now clamp to the viewport, wrap when
+  space runs short, and respect safe-area insets so controls stay reachable on
+  phones, tablets, and desktop window resizes.
 - **Colour cues and feedback.** Choosing a swatch briefly pulses every matching
   region (falling back to a celebratory flash when a colour is finished) so
   it's obvious where to paint next, and correctly filled regions immediately
@@ -84,9 +87,11 @@ tools, a save manager, and a configurable generator all live inside a single
 - **Precision view controls.** Pan the puzzle by click-dragging with the
   primary mouse button (spacebar, middle, and right buttons still work), use
   pinch gestures or the mouse wheel to zoom in and out, or tap `+`/`-` on the
-  keyboard for incremental adjustments. The canvas now stretches to fill the
-  viewport, centres itself automatically, and honours device orientation
-  changes without losing your place.
+  keyboard for incremental adjustments. Ctrl/Cmd zoom shortcuts now target the
+  puzzle instead of the surrounding UI so the HUD stays crisp while the canvas
+  reacts. The canvas stretches to fill the viewport, centres itself
+  automatically, and honours device orientation changes without losing your
+  place.
 - **Edge-to-edge stage.** A fullscreen toggle, rotation-aware sizing, and
   dynamic viewport padding ensure the command rail and palette scale cleanly on
   phones, tablets, or desktops while the artwork stays centred.

--- a/index.html
+++ b/index.html
@@ -35,7 +35,9 @@
           sans-serif;
         background: #020617;
         color: #e2e8f0;
-        --ui-scale: 1;
+        --ui-scale-user: 1;
+        --ui-scale-auto: 1;
+        --ui-scale: calc(var(--ui-scale-user, 1) * var(--ui-scale-auto, 1));
         --app-width: 100vw;
         --app-height: 100vh;
         --viewport-padding: calc(32px * var(--ui-scale));
@@ -43,8 +45,16 @@
         --rail-gap-portrait: calc(6px * var(--ui-scale));
         --rail-padding-block: calc(12px * var(--ui-scale));
         --rail-padding-inline: calc(24px * var(--ui-scale));
-        --command-button-size: calc(40px * var(--ui-scale));
-        --command-button-size-portrait: calc(36px * var(--ui-scale));
+        --command-button-size: clamp(
+          calc(32px * var(--ui-scale)),
+          calc(40px * var(--ui-scale)),
+          calc(48px * var(--ui-scale))
+        );
+        --command-button-size-portrait: clamp(
+          calc(30px * var(--ui-scale)),
+          calc(36px * var(--ui-scale)),
+          calc(44px * var(--ui-scale))
+        );
       }
 
       * {
@@ -93,10 +103,20 @@
         display: flex;
         justify-content: flex-end;
         align-items: center;
+        flex-wrap: wrap;
         gap: var(--rail-gap);
         padding: var(--rail-padding-block) var(--rail-padding-inline);
+        padding-block-start:
+          calc(var(--rail-padding-block) + env(safe-area-inset-top, 0px));
+        padding-block-end:
+          calc(var(--rail-padding-block) + env(safe-area-inset-bottom, 0px));
+        padding-inline-start:
+          calc(var(--rail-padding-inline) + env(safe-area-inset-left, 0px));
+        padding-inline-end:
+          calc(var(--rail-padding-inline) + env(safe-area-inset-right, 0px));
         z-index: 3;
         touch-action: manipulation;
+        width: 100%;
       }
 
       #commandRail button {
@@ -129,14 +149,26 @@
       }
 
       body[data-orientation="portrait"] #commandRail {
-        flex-wrap: wrap;
         gap: var(--rail-gap-portrait);
         padding: var(--rail-padding-block) calc(16px * var(--ui-scale));
+        justify-content: center;
+        width: 100%;
       }
 
       body[data-orientation="portrait"] #commandRail button {
         width: var(--command-button-size-portrait);
         height: var(--command-button-size-portrait);
+      }
+
+      body.compact-commands #commandRail {
+        justify-content: center;
+        gap: var(--rail-gap-portrait);
+        padding-inline: calc(16px * var(--ui-scale));
+      }
+
+      body.compact-commands #commandRail button {
+        width: min(var(--command-button-size), calc(14vw));
+        height: min(var(--command-button-size), calc(14vw));
       }
 
       body[data-orientation="portrait"] #paletteDock {
@@ -1469,6 +1501,14 @@
       function installBrowserZoomGuards() {
         if (typeof window === "undefined") return;
         let lastTouchEndTime = 0;
+        const isGameSurface = (node) => {
+          if (!(node instanceof Node)) return false;
+          if (canvasStage && canvasStage.contains(node)) return true;
+          if (canvasTransform && canvasTransform.contains(node)) return true;
+          if (puzzleCanvas && puzzleCanvas.contains(node)) return true;
+          if (viewportEl && viewportEl.contains(node)) return true;
+          return false;
+        };
 
         window.addEventListener(
           "touchend",
@@ -1496,6 +1536,51 @@
             { passive: false }
           );
         });
+
+        window.addEventListener(
+          "wheel",
+          (event) => {
+            if (!event) return;
+            if (!event.ctrlKey && !event.metaKey) return;
+            if (isInteractiveElementForZoomGuard(event.target)) return;
+            if (isGameSurface(event.target)) return;
+            event.preventDefault();
+          },
+          { passive: false, capture: true }
+        );
+
+        window.addEventListener(
+          "keydown",
+          (event) => {
+            if (!event) return;
+            if (!event.ctrlKey && !event.metaKey) return;
+            if (event.altKey) return;
+            if (isInteractiveElementForZoomGuard(event.target)) return;
+            const key = event.key;
+            const code = event.code;
+            const wantsReset = key === "0" || code === "Digit0" || code === "Numpad0";
+            const wantsZoomIn =
+              key === "+" || key === "=" || code === "Equal" || code === "NumpadAdd";
+            const wantsZoomOut = key === "-" || code === "Minus" || code === "NumpadSubtract";
+            if (!wantsReset && !wantsZoomIn && !wantsZoomOut) {
+              return;
+            }
+            event.preventDefault();
+            if (wantsReset) {
+              resetView({ preserveZoom: false, recenter: true });
+              return;
+            }
+            const allowShortcutTarget =
+              isGameSurface(event.target) ||
+              event.target === document.body ||
+              event.target === document.documentElement;
+            if (!allowShortcutTarget) {
+              return;
+            }
+            applyZoom(wantsZoomIn ? 1.1 : 0.9);
+          },
+          { capture: true }
+        );
 
         preventingBrowserZoom = true;
       }
@@ -1998,6 +2083,10 @@
       window.addEventListener("keydown", handleKeyDown, true);
       window.addEventListener("keyup", handleKeyUp, true);
       window.addEventListener("resize", () => handleViewportChange({ log: true }));
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", () => handleViewportChange({ log: true }));
+        window.visualViewport.addEventListener("scroll", () => handleViewportChange({ log: false }));
+      }
       window.addEventListener("blur", () => {
         spacePressed = false;
         if (panPointerId != null) {
@@ -2167,22 +2256,58 @@
         });
       }
 
+      function syncComputedUiScale() {
+        const root = document.documentElement;
+        const userValue =
+          typeof state?.settings?.uiScale === "number" ? state.settings.uiScale : 1;
+        if (!root) {
+          return userValue;
+        }
+        let autoValue = 1;
+        if (typeof window !== "undefined" && window.getComputedStyle) {
+          const styles = getComputedStyle(root);
+          const parsed = Number.parseFloat(styles.getPropertyValue("--ui-scale-auto"));
+          if (Number.isFinite(parsed)) {
+            autoValue = parsed;
+          }
+        } else {
+          const inlineAuto = Number.parseFloat(root.style.getPropertyValue("--ui-scale-auto"));
+          if (Number.isFinite(inlineAuto)) {
+            autoValue = inlineAuto;
+          }
+        }
+        const combined = clamp(userValue * autoValue, 0.6, 1.8);
+        root.style.setProperty("--ui-scale", combined.toFixed(4));
+        return combined;
+      }
+
       function updateViewportMetrics() {
-        const width = Math.round(window.innerWidth || document.documentElement.clientWidth || 0);
-        const height = Math.round(window.innerHeight || document.documentElement.clientHeight || 0);
-        const orientation = width >= height ? "landscape" : "portrait";
-        document.documentElement.style.setProperty("--app-width", `${width}px`);
-        document.documentElement.style.setProperty("--app-height", `${height}px`);
-        const minSide = Math.max(1, Math.min(width, height));
+        const viewport = window.visualViewport;
+        const visualWidth = Math.round(
+          viewport?.width || window.innerWidth || document.documentElement.clientWidth || 0
+        );
+        const visualHeight = Math.round(
+          viewport?.height || window.innerHeight || document.documentElement.clientHeight || 0
+        );
+        const orientation = visualWidth >= visualHeight ? "landscape" : "portrait";
+        document.documentElement.style.setProperty("--app-width", `${visualWidth}px`);
+        document.documentElement.style.setProperty("--app-height", `${visualHeight}px`);
+        const minSide = Math.max(1, Math.min(visualWidth, visualHeight));
         const padding = orientation === "portrait" ? Math.min(28, Math.max(16, Math.round(minSide * 0.06))) : 32;
         document.documentElement.style.setProperty("--viewport-padding", `${padding}px`);
+        const autoScale = clamp(minSide / 880, 0.8, 1.1);
+        document.documentElement.style.setProperty("--ui-scale-auto", autoScale.toFixed(3));
         if (document.body) {
           document.body.dataset.orientation = orientation;
+          const compact = visualWidth < 720 || visualHeight < 540;
+          document.body.classList.toggle("compact-commands", compact);
         }
+        syncComputedUiScale();
         const changed = orientation !== lastViewportMetrics.orientation;
-        const sizeChanged = width !== lastViewportMetrics.width || height !== lastViewportMetrics.height;
-        lastViewportMetrics = { orientation, width, height };
-        return { orientation, changed, sizeChanged, width, height };
+        const sizeChanged =
+          visualWidth !== lastViewportMetrics.width || visualHeight !== lastViewportMetrics.height;
+        lastViewportMetrics = { orientation, width: visualWidth, height: visualHeight };
+        return { orientation, changed, sizeChanged, width: visualWidth, height: visualHeight };
       }
 
       function handleViewportChange(options = {}) {
@@ -2372,7 +2497,8 @@
         const current = state.settings.uiScale ?? 1;
         const changed = force || Math.abs(resolved - current) > 0.001;
         state.settings.uiScale = resolved;
-        document.documentElement.style.setProperty("--ui-scale", String(resolved));
+        document.documentElement.style.setProperty("--ui-scale-user", String(resolved));
+        syncComputedUiScale();
         if (uiScaleInput && Math.abs(Number(uiScaleInput.value) - resolved) > 0.001) {
           uiScaleInput.value = String(resolved);
         }
@@ -3348,6 +3474,9 @@
 
       function handleKeyDown(event) {
         const target = event.target;
+        if (event.ctrlKey || event.metaKey) {
+          return;
+        }
         if (
           target instanceof HTMLInputElement ||
           target instanceof HTMLTextAreaElement ||


### PR DESCRIPTION
## Summary
- Clamp command rail sizing variables, respect safe-area insets, and add a compact layout class so icons always fit on screen.
- Sync UI scale with visual viewport metrics while intercepting browser zoom shortcuts to keep zooming focused on the puzzle.
- Document the responsive command rail and shortcut handling updates in the README.

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e4f93022b08331bd1d4f6eb704560c