### PR TITLE
Enhance palette focus and responsive command rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,18 @@ tools, a save manager, and a configurable generator all live inside a single
   trigger browser-level zoom; a global guard redirects them to the custom
   canvas handlers so the HUD stays stable while pan/zoom gestures still feel
   natural on touchscreens.
-- **Responsive command rail.** Header icons now clamp to the viewport, wrap when
-  space runs short, and respect safe-area insets so controls stay reachable on
-  phones, tablets, and desktop window resizes.
+- **Responsive command rail.** Controls are grouped into gameplay, view, and system clusters
+  so they rebalance gracefully across screen sizes. Wide layouts reveal button labels while
+  smaller devices collapse the rail into centred stacks. A dedicated detail button cycles the
+  Capybara sample presets without diving back into Settings.
 - **Colour cues and feedback.** Choosing a swatch briefly pulses every matching
   region (falling back to a celebratory flash when a colour is finished) so
   it's obvious where to paint next, and correctly filled regions immediately
   display the underlying illustration.
+- **Palette focus tools.** The dock now highlights the active colour with a live badge showing
+  its name, identifier, and remaining region count. A hide-finished toggle (also configurable in
+  Settings) collapses completed swatches so you can concentrate on unfinished colours while keeping
+  the current choice visible.
 - **Customisable background.** Pick a backdrop colour for unfinished regions in
   the Settings sheet; outlines and numbers automatically switch contrast so dark
   or light themes stay legible while you paint.
@@ -113,7 +118,9 @@ tools, a save manager, and a configurable generator all live inside a single
 ### Capybara Springs detail presets
 
 The Low/Medium/High detail chips on the onboarding hint and Settings sheet
-toggle tuned generator options for the built-in capybara vignette:
+toggle tuned generator options for the built-in capybara vignette, and the
+command rail includes a shortcut button that cycles through the presets in
+play:
 
 | Preset | Colours | Approx. regions | Min region | Resize edge | Sample rate | Iterations | Smoothing | Use it when… |
 | ------ | ------- | --------------- | ---------- | ----------- | ----------- | ---------- | --------- | ------------ |

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
         --viewport-padding: calc(32px * var(--ui-scale));
         --rail-gap: calc(8px * var(--ui-scale));
         --rail-gap-portrait: calc(6px * var(--ui-scale));
+        --rail-group-gap: calc(14px * var(--ui-scale));
         --rail-padding-block: calc(12px * var(--ui-scale));
         --rail-padding-inline: calc(24px * var(--ui-scale));
         --command-button-size: clamp(
@@ -101,10 +102,10 @@
       #commandRail {
         position: relative;
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         align-items: center;
         flex-wrap: wrap;
-        gap: var(--rail-gap);
+        gap: var(--rail-group-gap);
         padding: var(--rail-padding-block) var(--rail-padding-inline);
         padding-block-start:
           calc(var(--rail-padding-block) + env(safe-area-inset-top, 0px));
@@ -119,13 +120,33 @@
         width: 100%;
       }
 
+      #commandRail .command-group {
+        flex: 1 1 clamp(220px, 34vw, 420px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--rail-gap);
+        padding: calc(6px * var(--ui-scale)) calc(12px * var(--ui-scale));
+        border-radius: calc(24px * var(--ui-scale));
+        background: rgba(15, 23, 42, 0.68);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(14px);
+      }
+
+      #commandRail .command-group[data-group="system"] {
+        justify-content: flex-end;
+      }
+
       #commandRail button {
-        border-radius: 12px;
-        padding: 0;
-        width: var(--command-button-size);
-        height: var(--command-button-size);
+        border-radius: calc(18px * var(--ui-scale));
+        padding: calc(8px * var(--ui-scale)) calc(12px * var(--ui-scale));
+        min-width: var(--command-button-size);
+        min-height: var(--command-button-size);
         display: grid;
+        grid-template-rows: auto auto;
         place-items: center;
+        gap: calc(4px * var(--ui-scale));
         background: rgba(15, 23, 42, 0.82);
         color: rgba(226, 232, 240, 0.92);
         border: 1px solid rgba(148, 163, 184, 0.28);
@@ -138,8 +159,18 @@
       }
 
       #commandRail button .icon {
-        font-size: 1.1rem;
+        font-size: 1.15rem;
         line-height: 1;
+      }
+
+      #commandRail button .label {
+        display: none;
+        font-size: 0.65rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        line-height: 1.1;
+        opacity: 0.85;
       }
 
       #commandRail button:disabled {
@@ -149,15 +180,21 @@
       }
 
       body[data-orientation="portrait"] #commandRail {
-        gap: var(--rail-gap-portrait);
+        gap: var(--rail-group-gap);
         padding: var(--rail-padding-block) calc(16px * var(--ui-scale));
         justify-content: center;
         width: 100%;
       }
 
+      body[data-orientation="portrait"] #commandRail .command-group {
+        flex: 1 1 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
       body[data-orientation="portrait"] #commandRail button {
-        width: var(--command-button-size-portrait);
-        height: var(--command-button-size-portrait);
+        min-width: var(--command-button-size-portrait);
+        min-height: var(--command-button-size-portrait);
       }
 
       body.compact-commands #commandRail {
@@ -166,9 +203,35 @@
         padding-inline: calc(16px * var(--ui-scale));
       }
 
+      body.compact-commands #commandRail .command-group {
+        flex: 1 1 100%;
+        justify-content: center;
+        gap: calc(10px * var(--ui-scale));
+        padding-inline: calc(10px * var(--ui-scale));
+      }
+
       body.compact-commands #commandRail button {
-        width: min(var(--command-button-size), calc(14vw));
-        height: min(var(--command-button-size), calc(14vw));
+        width: min(var(--command-button-size), calc(16vw));
+        min-width: 0;
+        min-height: min(var(--command-button-size), calc(16vw));
+        padding: calc(8px * var(--ui-scale));
+      }
+
+      body.compact-commands #commandRail button .label {
+        display: none !important;
+      }
+
+      body.show-command-labels #commandRail .command-group {
+        justify-content: space-evenly;
+      }
+
+      body.show-command-labels #commandRail button {
+        min-width: calc(var(--command-button-size) * 1.18);
+        padding-block: calc(10px * var(--ui-scale));
+      }
+
+      body.show-command-labels #commandRail button .label {
+        display: block;
       }
 
       body[data-orientation="portrait"] #paletteDock {
@@ -514,10 +577,8 @@
 
       #paletteDock {
         position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: calc(16px * var(--ui-scale));
+        display: grid;
+        gap: calc(18px * var(--ui-scale));
         padding:
           calc(16px * var(--ui-scale))
           calc(28px * var(--ui-scale))
@@ -528,11 +589,120 @@
         touch-action: manipulation;
       }
 
+      .palette-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: calc(16px * var(--ui-scale));
+      }
+
+      .active-color {
+        flex: 1 1 320px;
+        display: flex;
+        align-items: center;
+        gap: calc(12px * var(--ui-scale));
+        padding: calc(10px * var(--ui-scale)) calc(14px * var(--ui-scale));
+        border-radius: calc(20px * var(--ui-scale));
+        background: rgba(15, 23, 42, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.22);
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+      }
+
+      body.compact-palette .active-color {
+        width: 100%;
+      }
+
+      .active-color[data-has-colour="false"] {
+        background: rgba(15, 23, 42, 0.6);
+        border-style: dashed;
+        border-color: rgba(148, 163, 184, 0.3);
+      }
+
+      .active-color .active-swatch {
+        width: calc(40px * var(--ui-scale));
+        height: calc(40px * var(--ui-scale));
+        border-radius: 14px;
+        background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(15, 23, 42, 0.6));
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .active-color .active-swatch::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: var(--active-color, linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(71, 85, 105, 0.35)));
+      }
+
+      .active-color .active-info {
+        display: grid;
+        gap: 2px;
+        min-width: 0;
+      }
+
+      .active-color .active-label {
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.85);
+      }
+
+      .active-color strong {
+        font-size: 1.05rem;
+        letter-spacing: 0.05em;
+        color: rgba(226, 232, 240, 0.95);
+      }
+
+      .active-color .active-name {
+        font-weight: 600;
+        font-size: 1.05rem;
+        margin: 0;
+        color: rgba(226, 232, 240, 0.95);
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+
+      .active-color .active-remaining {
+        margin: 0;
+        font-size: 0.85rem;
+        color: rgba(148, 163, 184, 0.9);
+      }
+
+      .palette-controls {
+        display: flex;
+        align-items: center;
+        gap: calc(12px * var(--ui-scale));
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      body.compact-palette #paletteDock {
+        gap: calc(14px * var(--ui-scale));
+      }
+
+      body.compact-palette .palette-meta {
+        flex-direction: column;
+        align-items: stretch;
+        gap: calc(12px * var(--ui-scale));
+      }
+
+      body.compact-palette .palette-controls {
+        justify-content: space-between;
+      }
+
+      body.compact-palette #progress {
+        text-align: left;
+      }
+
       #progress {
-        min-width: 120px;
+        min-width: 112px;
         font-size: 1.05rem;
         font-variant-numeric: tabular-nums;
-        text-align: left;
+        text-align: right;
         color: rgba(226, 232, 240, 0.82);
       }
 
@@ -545,6 +715,29 @@
         overflow-x: auto;
         padding: 2px 0 calc(6px * var(--ui-scale));
         scrollbar-width: thin;
+      }
+
+      #palette.hide-complete .swatch.done:not(.active) {
+        display: none;
+      }
+
+      button.ghost {
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        color: rgba(226, 232, 240, 0.85);
+        box-shadow: none;
+      }
+
+      button.ghost:hover:not(:disabled) {
+        transform: none;
+        box-shadow: none;
+        background: rgba(96, 165, 250, 0.16);
+      }
+
+      button.ghost.active {
+        background: rgba(37, 99, 235, 0.22);
+        border-color: rgba(96, 165, 250, 0.6);
+        color: rgba(226, 232, 240, 0.95);
       }
 
       #palette::-webkit-scrollbar {
@@ -1026,8 +1219,11 @@
         }
 
         #commandRail {
-          flex-wrap: wrap;
-          justify-content: flex-end;
+          justify-content: center;
+        }
+
+        #commandRail .command-group {
+          flex: 1 1 100%;
         }
       }
 
@@ -1040,14 +1236,19 @@
           max-height: calc(100vh - 240px);
         }
 
-        #paletteDock {
+        .palette-meta {
           flex-direction: column;
           align-items: stretch;
-          gap: 12px;
+          gap: calc(12px * var(--ui-scale));
+        }
+
+        .palette-controls {
+          justify-content: space-between;
         }
 
         #progress {
           min-width: 0;
+          text-align: left;
         }
       }
     </style>
@@ -1055,92 +1256,117 @@
   <body>
     <div id="app">
       <header id="commandRail" aria-label="Game controls">
-        <button
-          id="hintButton"
-          type="button"
-          data-testid="hint-button"
-          aria-label="Hint"
-          title="Hint"
-          disabled
-        >
-          <span class="icon" aria-hidden="true">?</span>
-        </button>
-        <button
-          id="resetButton"
-          type="button"
-          data-testid="reset-button"
-          aria-label="Reset puzzle"
-          title="Reset puzzle"
-          disabled
-        >
-          <span class="icon" aria-hidden="true">↺</span>
-        </button>
-        <button
-          id="previewToggle"
-          type="button"
-          data-testid="preview-toggle"
-          aria-label="Show preview"
-          title="Show preview"
-          disabled
-        >
-          <span class="icon" aria-hidden="true">🖼</span>
-        </button>
-        <button
-          id="sampleCommand"
-          type="button"
-          data-testid="sample-art-button"
-          data-action="load-sample"
-          aria-label="Reload sample puzzle"
-          title="Reload sample puzzle"
-        >
-          <span class="icon" aria-hidden="true">🐹</span>
-        </button>
-        <button
-          id="fullscreenButton"
-          type="button"
-          data-testid="fullscreen-button"
-          aria-label="Enter fullscreen"
-          title="Enter fullscreen"
-        >
-          <span class="icon" aria-hidden="true">⛶</span>
-        </button>
-        <button
-          id="importButton"
-          type="button"
-          data-testid="import-button"
-          aria-label="Import"
-          title="Import"
-        >
-          <span class="icon" aria-hidden="true">⬆</span>
-        </button>
-        <button
-          id="saveManagerButton"
-          type="button"
-          data-testid="save-manager-button"
-          aria-label="Save manager"
-          title="Save manager"
-          disabled
-        >
-          <span class="icon" aria-hidden="true">💾</span>
-        </button>
-        <button
-          id="helpButton"
-          type="button"
-          data-testid="help-button"
-          aria-label="Help &amp; shortcuts"
-          title="Help &amp; shortcuts"
-        >
-          <span class="icon" aria-hidden="true">ℹ</span>
-        </button>
-        <button
-          id="settingsButton"
-          type="button"
-          data-testid="settings-button"
-          aria-label="Settings"
-          title="Settings"
-        >
-          <span class="icon" aria-hidden="true">⚙</span>
-        </button>
+        <div class="command-group" data-group="play">
+          <button
+            id="hintButton"
+            type="button"
+            data-testid="hint-button"
+            aria-label="Hint"
+            title="Hint"
+            disabled
+          >
+            <span class="icon" aria-hidden="true">?</span>
+            <span class="label">Hint</span>
+          </button>
+          <button
+            id="resetButton"
+            type="button"
+            data-testid="reset-button"
+            aria-label="Reset puzzle"
+            title="Reset puzzle"
+            disabled
+          >
+            <span class="icon" aria-hidden="true">↺</span>
+            <span class="label">Reset</span>
+          </button>
+          <button
+            id="sampleCommand"
+            type="button"
+            data-testid="sample-art-button"
+            data-action="load-sample"
+            aria-label="Reload sample puzzle"
+            title="Reload sample puzzle"
+          >
+            <span class="icon" aria-hidden="true">🐹</span>
+            <span class="label">Sample</span>
+          </button>
+          <button
+            id="detailCycleButton"
+            type="button"
+            data-testid="detail-cycle-button"
+            aria-label="Cycle detail presets"
+            title="Cycle detail presets"
+          >
+            <span class="icon" aria-hidden="true">🎚</span>
+            <span class="label" data-detail-label>Detail</span>
+          </button>
+        </div>
+        <div class="command-group" data-group="view">
+          <button
+            id="previewToggle"
+            type="button"
+            data-testid="preview-toggle"
+            aria-label="Show preview"
+            title="Show preview"
+            disabled
+          >
+            <span class="icon" aria-hidden="true">🖼</span>
+            <span class="label">Preview</span>
+          </button>
+          <button
+            id="fullscreenButton"
+            type="button"
+            data-testid="fullscreen-button"
+            aria-label="Enter fullscreen"
+            title="Enter fullscreen"
+          >
+            <span class="icon" aria-hidden="true">⛶</span>
+            <span class="label">Fullscreen</span>
+          </button>
+        </div>
+        <div class="command-group" data-group="system">
+          <button
+            id="importButton"
+            type="button"
+            data-testid="import-button"
+            aria-label="Import"
+            title="Import"
+          >
+            <span class="icon" aria-hidden="true">⬆</span>
+            <span class="label">Import</span>
+          </button>
+          <button
+            id="saveManagerButton"
+            type="button"
+            data-testid="save-manager-button"
+            aria-label="Save manager"
+            title="Save manager"
+            disabled
+          >
+            <span class="icon" aria-hidden="true">💾</span>
+            <span class="label">Saves</span>
+          </button>
+          <button
+            id="helpButton"
+            type="button"
+            data-testid="help-button"
+            aria-label="Help &amp; shortcuts"
+            title="Help &amp; shortcuts"
+          >
+            <span class="icon" aria-hidden="true">ℹ</span>
+            <span class="label">Help</span>
+          </button>
+          <button
+            id="settingsButton"
+            type="button"
+            data-testid="settings-button"
+            aria-label="Settings"
+            title="Settings"
+          >
+            <span class="icon" aria-hidden="true">⚙</span>
+            <span class="label">Settings</span>
+          </button>
+        </div>
       </header>
       <div id="viewport">
         <div id="canvasStage">
@@ -1209,7 +1435,37 @@
         </div>
       </div>
       <footer id="paletteDock" aria-label="Palette dock" data-testid="palette-dock">
-        <div id="progress" aria-live="polite" data-testid="progress-message">—</div>
+        <div class="palette-meta">
+          <div
+            id="activeColorBadge"
+            class="active-color"
+            aria-live="polite"
+            data-has-colour="false"
+          >
+            <span class="active-swatch" data-active-color-swatch aria-hidden="true"></span>
+            <div class="active-info">
+              <span class="active-label">
+                <strong data-active-color-number>—</strong>
+              </span>
+              <p class="active-name" data-active-color-name>Pick a colour to start painting</p>
+              <p class="active-remaining" data-active-color-remaining>
+                Tap any swatch to highlight matching regions.
+              </p>
+            </div>
+          </div>
+          <div class="palette-controls">
+            <div id="progress" aria-live="polite" data-testid="progress-message">—</div>
+            <button
+              id="toggleCompletedColors"
+              type="button"
+              class="ghost"
+              aria-pressed="false"
+              title="Hide finished colours"
+            >
+              Hide finished colours
+            </button>
+          </div>
+        </div>
         <div id="palette" role="list"></div>
       </footer>
     </div>
@@ -1243,8 +1499,9 @@
               </dd>
               <dt>🎚 Detail</dt>
               <dd>
-                Toggle the capybara detail chips (start hint or Settings) to reload the sample with tuned
-                palette sizes, minimum region areas, resize targets, and the region counts noted above.
+                Cycle the sample detail presets from the command rail or use the chips in the start hint and
+                Settings sheet to reload the demo with tuned palette sizes, minimum region areas, resize
+                targets, and the region counts noted above.
               </dd>
             <dt>⛶ Fullscreen</dt>
             <dd>Expand the app to fill the display or exit back to windowed mode.</dd>
@@ -1259,6 +1516,10 @@
               Adjust generation sliders, toggle auto-advance, customise the background, resize the interface, or export JSON.
               Expand Advanced options to edit the hidden art prompt metadata when you need to capture the original brief.
             </dd>
+            <dt>👁 Hide finished colours</dt>
+            <dd>
+              Collapse completed swatches from the palette dock to focus on remaining colours; toggle again to show the full set.
+            </dd>
           </dl>
         </section>
         <section class="sheet-section" aria-labelledby="controlsHeading">
@@ -1269,6 +1530,7 @@
             <li><kbd>Mouse wheel</kbd> or <kbd>+</kbd>/<kbd>-</kbd> Zoom in or out around the cursor.</li>
             <li><kbd>Space</kbd> + drag (or middle/right drag) Pan the canvas.</li>
             <li>Drag &amp; drop an image or JSON file anywhere on the window to import it.</li>
+            <li>Use the palette toggle to hide finished colours when you want a cleaner strip of remaining swatches.</li>
           </ul>
         </section>
         <section class="sheet-section" aria-labelledby="debugHeading">
@@ -1320,6 +1582,13 @@
           </label>
           <p class="control-note">
             Applies to unfinished regions and adjusts outline contrast automatically.
+          </p>
+          <label class="toggle">
+            <input id="hideCompletedToggle" type="checkbox" />
+            <span>Hide finished colours in the palette</span>
+          </label>
+          <p class="control-note">
+            Completed swatches disappear until you show them again; the active colour stays visible.
           </p>
           <label class="control">
             <span>Interface scale <output data-for="uiScale">100%</output></span>
@@ -1421,6 +1690,7 @@
       const sampleDetailButtons = Array.from(document.querySelectorAll('[data-detail-level]'));
       const sampleDetailCaptions = Array.from(document.querySelectorAll('[data-detail-caption]'));
       const samplePreview = document.getElementById("sampleArtPreview");
+      const detailCycleButton = document.getElementById("detailCycleButton");
       const startHint = document.getElementById("startHint");
       const hintButton = document.getElementById("hintButton");
       const resetButton = document.getElementById("resetButton");
@@ -1445,6 +1715,7 @@
       const cursorNumberEl = cursorOverlay?.querySelector("[data-pointer-number]") || null;
       const autoAdvanceToggle = document.getElementById("autoAdvanceToggle");
       const hintFlashToggle = document.getElementById("hintFlashToggle");
+      const hideCompletedToggle = document.getElementById("hideCompletedToggle");
       const backgroundColorInput = document.getElementById("backgroundColor");
       const uiScaleInput = document.getElementById("uiScale");
       const colorCountEl = document.getElementById("colorCount");
@@ -1460,6 +1731,13 @@
       const saveList = document.getElementById("saveList");
       const paletteEl = document.getElementById("palette");
       const progressEl = document.getElementById("progress");
+      const toggleCompletedButton = document.getElementById("toggleCompletedColors");
+      const activeColorBadge = document.getElementById("activeColorBadge");
+      const activeColorSwatch = activeColorBadge?.querySelector("[data-active-color-swatch]") || null;
+      const activeColorNumberEl = activeColorBadge?.querySelector("[data-active-color-number]") || null;
+      const activeColorNameEl = activeColorBadge?.querySelector("[data-active-color-name]") || null;
+      const activeColorRemainingEl =
+        activeColorBadge?.querySelector("[data-active-color-remaining]") || null;
       const puzzleCanvas = document.getElementById("puzzleCanvas");
       const previewCanvas = document.getElementById("previewCanvas");
       const puzzleCtx = puzzleCanvas.getContext("2d");
@@ -1695,6 +1973,7 @@
           backgroundColor: DEFAULT_BACKGROUND_HEX,
           uiScale: 1,
           artPrompt: "",
+          hideCompletedColors: false,
         },
         previewVisible: false,
         saves: loadSavedEntries(),
@@ -1715,6 +1994,13 @@
           if (hintFlashToggle) {
             hintFlashToggle.checked = settings.animateHints;
           }
+        }
+        if (typeof settings.hideCompletedColors === "boolean") {
+          applyHideCompletedColors(settings.hideCompletedColors, {
+            skipLog: true,
+            skipAutosave: true,
+            skipRender: true,
+          });
         }
         if (typeof settings.uiScale === "number") {
           applyUiScale(settings.uiScale, { skipLog: true, skipAutosave: true });
@@ -1805,6 +2091,19 @@
         });
       }
 
+      if (detailCycleButton) {
+        detailCycleButton.addEventListener("click", () => {
+          const order = Object.keys(SAMPLE_DETAIL_LEVELS);
+          const currentId =
+            state.sampleDetailLevel && SAMPLE_DETAIL_LEVELS[state.sampleDetailLevel]
+              ? state.sampleDetailLevel
+              : DEFAULT_SAMPLE_DETAIL;
+          const currentIndex = Math.max(0, order.indexOf(currentId));
+          const nextId = order[(currentIndex + 1) % order.length];
+          applySampleDetailLevel(nextId);
+        });
+      }
+
       applySampleDetailLevel(DEFAULT_SAMPLE_DETAIL, { skipReload: true, skipLog: true });
 
       const restoredSession = loadInitialSession();
@@ -1819,6 +2118,16 @@
       if (helpButton) {
         helpButton.addEventListener("click", () => openSheet(helpSheet));
       }
+
+      if (toggleCompletedButton) {
+        toggleCompletedButton.addEventListener("click", () => {
+          applyHideCompletedColors(!state.settings.hideCompletedColors);
+        });
+      }
+
+      updateHideCompletedButton();
+      updateActiveColorBadge(null);
+      updateDetailCycleButtonState();
 
       if (fullscreenButton) {
         fullscreenButton.addEventListener("click", () => toggleFullscreen());
@@ -1881,6 +2190,12 @@
         logDebug(`Hint animations ${hintFlashToggle.checked ? "enabled" : "disabled"}`);
         scheduleAutosave("settings-hint-animations");
       });
+
+      if (hideCompletedToggle) {
+        hideCompletedToggle.addEventListener("change", (event) => {
+          applyHideCompletedColors(Boolean(event.target.checked));
+        });
+      }
 
       if (backgroundColorInput) {
         backgroundColorInput.addEventListener("input", (event) => {
@@ -2299,8 +2614,12 @@
         document.documentElement.style.setProperty("--ui-scale-auto", autoScale.toFixed(3));
         if (document.body) {
           document.body.dataset.orientation = orientation;
-          const compact = visualWidth < 720 || visualHeight < 540;
-          document.body.classList.toggle("compact-commands", compact);
+          const compactCommands = visualWidth < 720 || visualHeight < 540;
+          const compactPalette = visualHeight < 600 || visualWidth < 880;
+          const showLabels = visualWidth >= 1280 && visualHeight >= 720;
+          document.body.classList.toggle("compact-commands", compactCommands);
+          document.body.classList.toggle("compact-palette", compactPalette);
+          document.body.classList.toggle("show-command-labels", showLabels);
         }
         syncComputedUiScale();
         const changed = orientation !== lastViewportMetrics.orientation;
@@ -2323,6 +2642,30 @@
           resetView({ preserveZoom: true, recenter: recenter || orientationChanged });
         }
         hideCustomCursor();
+      }
+
+      function updateDetailCycleButtonState() {
+        if (!detailCycleButton) return;
+        const activeConfig =
+          SAMPLE_DETAIL_LEVELS[state.sampleDetailLevel] || SAMPLE_DETAIL_LEVELS[DEFAULT_SAMPLE_DETAIL];
+        const labelEl = detailCycleButton.querySelector("[data-detail-label]");
+        if (labelEl) {
+          labelEl.textContent = activeConfig?.shortLabel || activeConfig?.label || "Detail";
+        }
+        const order = Object.keys(SAMPLE_DETAIL_LEVELS);
+        const currentId = activeConfig?.id || DEFAULT_SAMPLE_DETAIL;
+        const currentIndex = Math.max(0, order.indexOf(currentId));
+        const nextId = order[(currentIndex + 1) % order.length];
+        const nextConfig = SAMPLE_DETAIL_LEVELS[nextId];
+        const summary = activeConfig?.summary || activeConfig?.label || "Detail presets";
+        const nextLabel = nextConfig?.label || nextConfig?.summary || nextId;
+        const aria = nextLabel
+          ? `${summary} active. Next: ${nextLabel}.`
+          : `${summary} active.`;
+        detailCycleButton.setAttribute("aria-label", aria);
+        detailCycleButton.title = nextLabel
+          ? `Cycle detail presets (next: ${nextLabel})`
+          : "Cycle detail presets";
       }
 
       function applySampleDetailLevel(level, options = {}) {
@@ -2349,6 +2692,7 @@
             caption.textContent = config.summary;
           }
         }
+        updateDetailCycleButtonState();
         for (const button of sampleButtons) {
           if (!button) continue;
           const labelBase = `Reload ${SAMPLE_ARTWORK.title}`;
@@ -2566,6 +2910,83 @@
         return normalized;
       }
 
+      function updateHideCompletedButton() {
+        if (!toggleCompletedButton) return;
+        const active = Boolean(state.settings.hideCompletedColors);
+        toggleCompletedButton.classList.toggle("active", active);
+        toggleCompletedButton.setAttribute("aria-pressed", active ? "true" : "false");
+        const label = active ? "Show finished colours" : "Hide finished colours";
+        toggleCompletedButton.textContent = active ? "Show all colours" : "Hide finished colours";
+        toggleCompletedButton.title = label;
+        toggleCompletedButton.setAttribute("aria-label", label);
+      }
+
+      function updateActiveColorBadge(stats = null) {
+        if (!activeColorBadge) return;
+        const hasColour = Boolean(stats && stats.paletteEntry);
+        activeColorBadge.dataset.hasColour = hasColour ? "true" : "false";
+        if (!hasColour) {
+          if (activeColorSwatch) {
+            activeColorSwatch.style.removeProperty("--active-color");
+          }
+          if (activeColorNumberEl) {
+            activeColorNumberEl.textContent = "—";
+          }
+          if (activeColorNameEl) {
+            activeColorNameEl.textContent = "Pick a colour to start painting";
+          }
+          if (activeColorRemainingEl) {
+            activeColorRemainingEl.textContent = "Tap any swatch to highlight matching regions.";
+          }
+          return;
+        }
+        const { paletteEntry, total = 0, remaining = 0 } = stats;
+        if (activeColorSwatch) {
+          if (paletteEntry?.hex) {
+            activeColorSwatch.style.setProperty("--active-color", paletteEntry.hex);
+          } else {
+            activeColorSwatch.style.removeProperty("--active-color");
+          }
+        }
+        if (activeColorNumberEl) {
+          activeColorNumberEl.textContent = `#${paletteEntry.id}`;
+        }
+        if (activeColorNameEl) {
+          activeColorNameEl.textContent = paletteEntry.name || `Colour ${paletteEntry.id}`;
+        }
+        if (activeColorRemainingEl) {
+          const message =
+            remaining > 0
+              ? `${remaining} of ${total} regions unfinished`
+              : `All ${total} regions complete`;
+          activeColorRemainingEl.textContent = message;
+        }
+      }
+
+      function applyHideCompletedColors(value, options = {}) {
+        const { skipLog = false, skipAutosave = false, skipRender = false } = options;
+        const resolved = Boolean(value);
+        const previous = Boolean(state.settings.hideCompletedColors);
+        state.settings.hideCompletedColors = resolved;
+        if (paletteEl) {
+          paletteEl.classList.toggle("hide-complete", resolved);
+        }
+        if (hideCompletedToggle && hideCompletedToggle.checked !== resolved) {
+          hideCompletedToggle.checked = resolved;
+        }
+        updateHideCompletedButton();
+        if (!skipRender && previous !== resolved) {
+          renderPalette();
+        }
+        if (previous !== resolved && !skipLog) {
+          logDebug(resolved ? "Hiding completed colours from palette" : "Showing all palette colours");
+        }
+        if (previous !== resolved && !skipAutosave) {
+          scheduleAutosave("settings-hide-complete");
+        }
+        return resolved;
+      }
+
       function updateOptionOutputs() {
         if (optionOutputs.colorCount) optionOutputs.colorCount.textContent = String(colorCountEl.value);
         if (optionOutputs.minRegion) optionOutputs.minRegion.textContent = `${minRegionEl.value} px²`;
@@ -2706,8 +3127,15 @@
         state.filled = new Set();
         state.sourceUrl = null;
         state.sourceTitle = null;
-        paletteEl.innerHTML = "";
-        progressEl.textContent = "…";
+        if (paletteEl) {
+          paletteEl.innerHTML = "";
+          paletteEl.classList.toggle("hide-complete", Boolean(state.settings.hideCompletedColors));
+        }
+        if (progressEl) {
+          progressEl.textContent = "…";
+        }
+        updateActiveColorBadge(null);
+        updateHideCompletedButton();
         puzzleCtx.clearRect(0, 0, puzzleCanvas.width, puzzleCanvas.height);
         previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
         state.previewImageData = null;
@@ -2898,6 +3326,16 @@
         const resolvedSettings = metadata.settings ?? data.settings;
         if (resolvedSettings) {
           applyGameplaySettings(resolvedSettings);
+        }
+        const resolvedDetailLevel = metadata.sampleDetailLevel ?? data.sampleDetailLevel;
+        if (resolvedDetailLevel) {
+          applySampleDetailLevel(resolvedDetailLevel, {
+            skipReload: true,
+            skipLog: true,
+            skipOptions: true,
+          });
+        } else {
+          updateDetailCycleButtonState();
         }
         applyBackgroundColor(backgroundHex, { skipRender: true, skipLog: true });
         puzzleCanvas.width = data.width;
@@ -3418,8 +3856,14 @@
       }
 
       function renderPalette() {
+        if (!paletteEl) return;
         paletteEl.innerHTML = "";
-        if (!state.puzzle) return;
+        paletteEl.classList.toggle("hide-complete", Boolean(state.settings.hideCompletedColors));
+        if (!state.puzzle) {
+          updateActiveColorBadge(null);
+          updateHideCompletedButton();
+          return;
+        }
         const totalByColor = new Map();
         const remainingByColor = new Map();
         for (const region of state.puzzle.regions) {
@@ -3460,6 +3904,19 @@
           });
           paletteEl.appendChild(swatch);
         }
+        const activeId = state.activeColor;
+        const paletteEntry =
+          activeId != null ? state.puzzle.palette.find((entry) => entry.id === activeId) || null : null;
+        const stats =
+          paletteEntry && paletteEntry.id != null
+            ? {
+                paletteEntry,
+                total: totalByColor.get(paletteEntry.id) || 0,
+                remaining: remainingByColor.get(paletteEntry.id) || 0,
+              }
+            : null;
+        updateActiveColorBadge(stats);
+        updateHideCompletedButton();
       }
 
       function updateProgress() {
@@ -4144,7 +4601,9 @@
             animateHints: Boolean(state.settings.animateHints),
             uiScale: Number(state.settings.uiScale) || 1,
             artPrompt: state.settings.artPrompt || "",
+            hideCompletedColors: Boolean(state.settings.hideCompletedColors),
           },
+          sampleDetailLevel: state.sampleDetailLevel,
         };
         if (regionMapPacked) {
           payload.regionMapPacked = regionMapPacked;

--- a/tests/ui-review.spec.js
+++ b/tests/ui-review.spec.js
@@ -112,6 +112,24 @@ test.describe('Capy image generator', () => {
       ])
     );
 
+    await expect(page.locator('#detailCycleButton')).toBeVisible();
+    const detailAria = await page.locator('#detailCycleButton').getAttribute('aria-label');
+    expect(detailAria || '').toMatch(/Next:/);
+
+    const paletteToggle = page.locator('#toggleCompletedColors');
+    await expect(paletteToggle).toBeVisible();
+    await expect(paletteToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(paletteToggle).toHaveText(/Hide finished colours/i);
+
+    await expect(page.locator('#activeColorBadge')).toHaveAttribute('data-has-colour', 'true');
+
+    await paletteToggle.click();
+    await expect(paletteToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(paletteToggle).toHaveText(/Show all colours/i);
+    await paletteToggle.click();
+    await expect(paletteToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(paletteToggle).toHaveText(/Hide finished colours/i);
+
     await page.click('#helpButton');
     await expect(page.locator('#helpSheet')).toBeVisible();
 
@@ -139,6 +157,7 @@ test.describe('Capy image generator', () => {
     expect(generatorLabels.some((label) => label.includes('Sample rate'))).toBe(true);
     expect(generatorLabels.some((label) => label.includes('Background colour'))).toBe(true);
     expect(generatorLabels.some((label) => label.includes('Interface scale'))).toBe(true);
+    await expect(page.locator('#hideCompletedToggle')).toBeVisible();
 
     const artPrompt = page.locator('#artPrompt');
     await expect(artPrompt).toBeHidden();
@@ -190,6 +209,16 @@ test.describe('Capy image generator', () => {
     expect(state.sourceUrl).toContain('data:image/svg+xml;base64,');
     expect(state.detailLevel).toBe('high');
     expect(state.targetColors).toBe(32);
+
+    const badgeState = await page.evaluate(() => {
+      const badge = document.querySelector('#activeColorBadge');
+      return {
+        hasColour: badge?.dataset.hasColour || null,
+        remaining: badge?.querySelector('[data-active-color-remaining]')?.textContent?.trim() || '',
+      };
+    });
+    expect(badgeState.hasColour).toBe('true');
+    expect(badgeState.remaining).toMatch(/regions/);
 
     await page.click('[data-testid="sample-art-button"]');
     await expect


### PR DESCRIPTION
## Summary
- group the command rail into responsive clusters, surface button labels on wide screens, and add a detail preset shortcut
- introduce an active colour badge plus a hide-finished toggle in the palette with a matching setting
- update documentation and UI tests to cover the new controls and palette behaviour

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e50705b4cc833199eb19d78b764412