### PR TITLE
Merge branch 'codex/fix-screen-size-and-zoom-issues-8qpebx'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,13 @@ tools, a save manager, and a configurable generator all live inside a single
   trigger browser-level zoom; a global guard redirects them to the custom
   canvas handlers so the HUD stays stable while pan/zoom gestures still feel
   natural on touchscreens.
-- **Responsive command rail.** Controls are grouped into gameplay, view, and system clusters
-  so they rebalance gracefully across screen sizes. Wide layouts reveal button labels while
-  smaller devices collapse the rail into centred stacks. A dedicated detail button cycles the
-  Capybara sample presets without diving back into Settings.
+- **Responsive command rail.** Header icons now clamp to the viewport, wrap when
+  space runs short, and respect safe-area insets so controls stay reachable on
+  phones, tablets, and desktop window resizes.
 - **Colour cues and feedback.** Choosing a swatch briefly pulses every matching
   region (falling back to a celebratory flash when a colour is finished) so
   it's obvious where to paint next, and correctly filled regions immediately
   display the underlying illustration.
-- **Palette focus tools.** The dock now highlights the active colour with a live badge showing
-  its name, identifier, and remaining region count. A hide-finished toggle (also configurable in
-  Settings) collapses completed swatches so you can concentrate on unfinished colours while keeping
-  the current choice visible.
 - **Customisable background.** Pick a backdrop colour for unfinished regions in
   the Settings sheet; outlines and numbers automatically switch contrast so dark
   or light themes stay legible while you paint.
@@ -118,9 +113,7 @@ tools, a save manager, and a configurable generator all live inside a single
 ### Capybara Springs detail presets
 
 The Low/Medium/High detail chips on the onboarding hint and Settings sheet
-toggle tuned generator options for the built-in capybara vignette, and the
-command rail includes a shortcut button that cycles through the presets in
-play:
+toggle tuned generator options for the built-in capybara vignette:
 
 | Preset | Colours | Approx. regions | Min region | Resize edge | Sample rate | Iterations | Smoothing | Use it when… |
 | ------ | ------- | --------------- | ---------- | ----------- | ----------- | ---------- | --------- | ------------ |
@@ -258,8 +251,9 @@ before retrying.
 - **Fullscreen preview overlay** – Triggered by the Preview button. The preview
   canvas stretches to fit the viewport so contributors can inspect the clustered
   output in detail before painting.
-- **Progress indicator** – A numeric tally in the palette dock that tracks
-  completed versus total regions and announces updates politely via `aria-live`.
+- **Progress indicator** – A friendly status message in the palette dock that
+  announces progress changes (Ready to colour, Keep colouring, All done!) via
+  `aria-live` rather than exposing raw region counts.
 - **Settings sheet** – A modal sheet that hides the generation sliders by
   default. Controls include colours, minimum region size, resize detail, sample
   rate, k-means iterations, smoothing passes, a background colour picker, and
@@ -287,7 +281,7 @@ before retrying.
 
 - The hint overlay is focusable and reacts to Enter/Space to trigger the file
   picker, keeping the first interaction accessible.
-- The progress tally uses `aria-live="polite"` announcements so assistive tech
+- The progress status uses `aria-live="polite"` announcements so assistive tech
   hears every completion update, and the help sheet’s debug log mirrors the same
   polite live region for gameplay telemetry.
 - Command rail buttons expose descriptive `aria-label` and `title` attributes
@@ -310,7 +304,7 @@ before retrying.
 The Playwright suite exercises the core flows:
 
 - **renders command rail and generator settings on load** – Confirms the hint
-  overlay, iconized command rail, compact progress tally, and generator controls
+  overlay, iconized command rail, compact progress status, and generator controls
   render on first boot.
  - **auto loads the capybara sample scene** – Verifies the bundled illustration is
     ready as soon as the app boots, that the sample button still reloads it on
@@ -334,24 +328,10 @@ npm test --silent
 The suite writes artifacts (screenshots + JSON summaries) into
 `artifacts/ui-review/` if you need to inspect the DOM snapshots.
 
-### Automation-first workflow
+## TODO
 
-Keep the repository automation-friendly by following this loop:
-
-1. `git fetch --all --prune` and merge or rebase `main` so local work starts
-   from the freshest automation expectations.
-2. Implement the change behind a focused branch, updating docs like
-   `AGENTS.md` when workflow guidance shifts.
-3. Run `npm test --silent` (or targeted subsets when iterating) to exercise the
-   UI review harness before committing.
-4. Commit with descriptive summaries, push the branch, and open a PR that calls
-   out any workflow impacts for reviewers.
-
-### Safe repository searches
-
-Ripgrep is configured via [`.ripgreprc`](.ripgreprc) to clamp printed line
-widths and avoid flooding the terminal with megabyte-long rows. The matching
-ignore file [`.rgignore`](.rgignore) skips generated assets and Playwright
-artifacts so ad-hoc searches stay fast even on large fixtures. If you need to
-inspect those folders, pass `--no-ignore` explicitly.
+- [ ] Restore artwork documentation once a new segmentation pipeline is ready for publication.
+- [ ] Add automated visual regression coverage beyond the current smoke test to guard the trimmed UI.
+- [ ] Wire the Playwright CI job to automatically upload `artifacts/ui-review/` bundles to the Automation Sync dashboard.
+- [ ] Draft a GitHub issue template for the weekly Automation Sync summary and link it from the contributor guide.
 

--- a/docs/merge-conflict-report.md
+++ b/docs/merge-conflict-report.md
@@ -1,0 +1,24 @@
+# Merge Conflict Report: Zoom Guard Branch vs Main
+
+## Overview
+Merging the zoom guard updates into `main` previously raised a conflict in `index.html`.
+Both branches adjusted the keyboard and wheel shortcut suppression inside
+`installBrowserZoomGuards`, so Git could not reconcile the ordering differences on its
+own.
+
+## Conflict Location
+The disagreement lived in the wheel shortcut handler. One side cached the interactive and
+stage checks before calling `preventDefault`, while the other invoked the helpers inline.
+A matching pattern appeared in the keyboard handler, where one side reused the cached
+boolean and the other re-ran the helper check.
+
+## Resolution
+We now settle on a shared structure for both handlers:
+
+- Cache `isInteractiveElementForZoomGuard(event.target)` once at the top.
+- Return early for interactive UI controls.
+- Let canvas targets fall through so the stage-specific handlers own zooming.
+- Call `event.preventDefault()` only when the browser shortcut should be cancelled.
+
+With both handlers following the same control flow, the merge conflict is resolved and the
+browser zoom guards behave consistently across keyboard and wheel shortcuts.

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
         --viewport-padding: calc(32px * var(--ui-scale));
         --rail-gap: calc(8px * var(--ui-scale));
         --rail-gap-portrait: calc(6px * var(--ui-scale));
-        --rail-group-gap: calc(14px * var(--ui-scale));
         --rail-padding-block: calc(12px * var(--ui-scale));
         --rail-padding-inline: calc(24px * var(--ui-scale));
         --command-button-size: clamp(
@@ -102,10 +101,10 @@
       #commandRail {
         position: relative;
         display: flex;
-        justify-content: space-between;
+        justify-content: flex-end;
         align-items: center;
         flex-wrap: wrap;
-        gap: var(--rail-group-gap);
+        gap: var(--rail-gap);
         padding: var(--rail-padding-block) var(--rail-padding-inline);
         padding-block-start:
           calc(var(--rail-padding-block) + env(safe-area-inset-top, 0px));
@@ -120,33 +119,13 @@
         width: 100%;
       }
 
-      #commandRail .command-group {
-        flex: 1 1 clamp(220px, 34vw, 420px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: var(--rail-gap);
-        padding: calc(6px * var(--ui-scale)) calc(12px * var(--ui-scale));
-        border-radius: calc(24px * var(--ui-scale));
-        background: rgba(15, 23, 42, 0.68);
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
-        backdrop-filter: blur(14px);
-      }
-
-      #commandRail .command-group[data-group="system"] {
-        justify-content: flex-end;
-      }
-
       #commandRail button {
-        border-radius: calc(18px * var(--ui-scale));
-        padding: calc(8px * var(--ui-scale)) calc(12px * var(--ui-scale));
-        min-width: var(--command-button-size);
-        min-height: var(--command-button-size);
+        border-radius: 12px;
+        padding: 0;
+        width: var(--command-button-size);
+        height: var(--command-button-size);
         display: grid;
-        grid-template-rows: auto auto;
         place-items: center;
-        gap: calc(4px * var(--ui-scale));
         background: rgba(15, 23, 42, 0.82);
         color: rgba(226, 232, 240, 0.92);
         border: 1px solid rgba(148, 163, 184, 0.28);
@@ -159,18 +138,8 @@
       }
 
       #commandRail button .icon {
-        font-size: 1.15rem;
+        font-size: 1.1rem;
         line-height: 1;
-      }
-
-      #commandRail button .label {
-        display: none;
-        font-size: 0.65rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        line-height: 1.1;
-        opacity: 0.85;
       }
 
       #commandRail button:disabled {
@@ -180,21 +149,15 @@
       }
 
       body[data-orientation="portrait"] #commandRail {
-        gap: var(--rail-group-gap);
+        gap: var(--rail-gap-portrait);
         padding: var(--rail-padding-block) calc(16px * var(--ui-scale));
         justify-content: center;
         width: 100%;
       }
 
-      body[data-orientation="portrait"] #commandRail .command-group {
-        flex: 1 1 100%;
-        justify-content: center;
-        flex-wrap: wrap;
-      }
-
       body[data-orientation="portrait"] #commandRail button {
-        min-width: var(--command-button-size-portrait);
-        min-height: var(--command-button-size-portrait);
+        width: var(--command-button-size-portrait);
+        height: var(--command-button-size-portrait);
       }
 
       body.compact-commands #commandRail {
@@ -203,35 +166,9 @@
         padding-inline: calc(16px * var(--ui-scale));
       }
 
-      body.compact-commands #commandRail .command-group {
-        flex: 1 1 100%;
-        justify-content: center;
-        gap: calc(10px * var(--ui-scale));
-        padding-inline: calc(10px * var(--ui-scale));
-      }
-
       body.compact-commands #commandRail button {
-        width: min(var(--command-button-size), calc(16vw));
-        min-width: 0;
-        min-height: min(var(--command-button-size), calc(16vw));
-        padding: calc(8px * var(--ui-scale));
-      }
-
-      body.compact-commands #commandRail button .label {
-        display: none !important;
-      }
-
-      body.show-command-labels #commandRail .command-group {
-        justify-content: space-evenly;
-      }
-
-      body.show-command-labels #commandRail button {
-        min-width: calc(var(--command-button-size) * 1.18);
-        padding-block: calc(10px * var(--ui-scale));
-      }
-
-      body.show-command-labels #commandRail button .label {
-        display: block;
+        width: min(var(--command-button-size), calc(14vw));
+        height: min(var(--command-button-size), calc(14vw));
       }
 
       body[data-orientation="portrait"] #paletteDock {
@@ -577,8 +514,10 @@
 
       #paletteDock {
         position: relative;
-        display: grid;
-        gap: calc(18px * var(--ui-scale));
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: calc(16px * var(--ui-scale));
         padding:
           calc(16px * var(--ui-scale))
           calc(28px * var(--ui-scale))
@@ -589,155 +528,24 @@
         touch-action: manipulation;
       }
 
-      .palette-meta {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        flex-wrap: wrap;
-        gap: calc(16px * var(--ui-scale));
-      }
-
-      .active-color {
-        flex: 1 1 320px;
-        display: flex;
-        align-items: center;
-        gap: calc(12px * var(--ui-scale));
-        padding: calc(10px * var(--ui-scale)) calc(14px * var(--ui-scale));
-        border-radius: calc(20px * var(--ui-scale));
-        background: rgba(15, 23, 42, 0.78);
-        border: 1px solid rgba(148, 163, 184, 0.22);
-        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
-      }
-
-      body.compact-palette .active-color {
-        width: 100%;
-      }
-
-      .active-color[data-has-colour="false"] {
-        background: rgba(15, 23, 42, 0.6);
-        border-style: dashed;
-        border-color: rgba(148, 163, 184, 0.3);
-      }
-
-      .active-color .active-swatch {
-        width: calc(40px * var(--ui-scale));
-        height: calc(40px * var(--ui-scale));
-        border-radius: 14px;
-        background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(15, 23, 42, 0.6));
-        border: 1px solid rgba(148, 163, 184, 0.28);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .active-color .active-swatch::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        background: var(--active-color, linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(71, 85, 105, 0.35)));
-      }
-
-      .active-color .active-info {
-        display: grid;
-        gap: 2px;
-        min-width: 0;
-      }
-
-      .active-color .active-label {
-        font-size: 0.85rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: rgba(148, 163, 184, 0.85);
-      }
-
-      .active-color strong {
-        font-size: 1.05rem;
-        letter-spacing: 0.05em;
-        color: rgba(226, 232, 240, 0.95);
-      }
-
-      .active-color .active-name {
-        font-weight: 600;
-        font-size: 1.05rem;
-        margin: 0;
-        color: rgba(226, 232, 240, 0.95);
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden;
-      }
-
-      .active-color .active-remaining {
-        margin: 0;
-        font-size: 0.85rem;
-        color: rgba(148, 163, 184, 0.9);
-      }
-
-      .palette-controls {
-        display: flex;
-        align-items: center;
-        gap: calc(12px * var(--ui-scale));
-        flex-wrap: wrap;
-        justify-content: flex-end;
-      }
-
-      body.compact-palette #paletteDock {
-        gap: calc(14px * var(--ui-scale));
-      }
-
-      body.compact-palette .palette-meta {
-        flex-direction: column;
-        align-items: stretch;
-        gap: calc(12px * var(--ui-scale));
-      }
-
-      body.compact-palette .palette-controls {
-        justify-content: space-between;
-      }
-
-      body.compact-palette #progress {
-        text-align: left;
-      }
-
       #progress {
-        min-width: 112px;
+        min-width: 120px;
         font-size: 1.05rem;
         font-variant-numeric: tabular-nums;
-        text-align: right;
+        text-align: left;
         color: rgba(226, 232, 240, 0.82);
       }
 
       #palette {
         flex: 1;
-        display: grid;
-        grid-auto-flow: column;
-        grid-auto-columns: minmax(calc(44px * var(--ui-scale)), 1fr);
+        display: flex;
         gap: calc(6px * var(--ui-scale));
         overflow-x: auto;
+        overflow-y: hidden;
         padding: 2px 0 calc(6px * var(--ui-scale));
         scrollbar-width: thin;
-      }
-
-      #palette.hide-complete .swatch.done:not(.active) {
-        display: none;
-      }
-
-      button.ghost {
-        background: rgba(15, 23, 42, 0.55);
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        color: rgba(226, 232, 240, 0.85);
-        box-shadow: none;
-      }
-
-      button.ghost:hover:not(:disabled) {
-        transform: none;
-        box-shadow: none;
-        background: rgba(96, 165, 250, 0.16);
-      }
-
-      button.ghost.active {
-        background: rgba(37, 99, 235, 0.22);
-        border-color: rgba(96, 165, 250, 0.6);
-        color: rgba(226, 232, 240, 0.95);
+        -webkit-overflow-scrolling: touch;
+        touch-action: pan-x;
       }
 
       #palette::-webkit-scrollbar {
@@ -902,6 +710,7 @@
       }
 
       .swatch {
+        flex: 0 0 auto;
         position: relative;
         display: flex;
         flex-direction: column;
@@ -1219,11 +1028,8 @@
         }
 
         #commandRail {
-          justify-content: center;
-        }
-
-        #commandRail .command-group {
-          flex: 1 1 100%;
+          flex-wrap: wrap;
+          justify-content: flex-end;
         }
       }
 
@@ -1236,19 +1042,14 @@
           max-height: calc(100vh - 240px);
         }
 
-        .palette-meta {
+        #paletteDock {
           flex-direction: column;
           align-items: stretch;
-          gap: calc(12px * var(--ui-scale));
-        }
-
-        .palette-controls {
-          justify-content: space-between;
+          gap: 12px;
         }
 
         #progress {
           min-width: 0;
-          text-align: left;
         }
       }
     </style>
@@ -1256,117 +1057,92 @@
   <body>
     <div id="app">
       <header id="commandRail" aria-label="Game controls">
-        <div class="command-group" data-group="play">
-          <button
-            id="hintButton"
-            type="button"
-            data-testid="hint-button"
-            aria-label="Hint"
-            title="Hint"
-            disabled
-          >
-            <span class="icon" aria-hidden="true">?</span>
-            <span class="label">Hint</span>
-          </button>
-          <button
-            id="resetButton"
-            type="button"
-            data-testid="reset-button"
-            aria-label="Reset puzzle"
-            title="Reset puzzle"
-            disabled
-          >
-            <span class="icon" aria-hidden="true">↺</span>
-            <span class="label">Reset</span>
-          </button>
-          <button
-            id="sampleCommand"
-            type="button"
-            data-testid="sample-art-button"
-            data-action="load-sample"
-            aria-label="Reload sample puzzle"
-            title="Reload sample puzzle"
-          >
-            <span class="icon" aria-hidden="true">🐹</span>
-            <span class="label">Sample</span>
-          </button>
-          <button
-            id="detailCycleButton"
-            type="button"
-            data-testid="detail-cycle-button"
-            aria-label="Cycle detail presets"
-            title="Cycle detail presets"
-          >
-            <span class="icon" aria-hidden="true">🎚</span>
-            <span class="label" data-detail-label>Detail</span>
-          </button>
-        </div>
-        <div class="command-group" data-group="view">
-          <button
-            id="previewToggle"
-            type="button"
-            data-testid="preview-toggle"
-            aria-label="Show preview"
-            title="Show preview"
-            disabled
-          >
-            <span class="icon" aria-hidden="true">🖼</span>
-            <span class="label">Preview</span>
-          </button>
-          <button
-            id="fullscreenButton"
-            type="button"
-            data-testid="fullscreen-button"
-            aria-label="Enter fullscreen"
-            title="Enter fullscreen"
-          >
-            <span class="icon" aria-hidden="true">⛶</span>
-            <span class="label">Fullscreen</span>
-          </button>
-        </div>
-        <div class="command-group" data-group="system">
-          <button
-            id="importButton"
-            type="button"
-            data-testid="import-button"
-            aria-label="Import"
-            title="Import"
-          >
-            <span class="icon" aria-hidden="true">⬆</span>
-            <span class="label">Import</span>
-          </button>
-          <button
-            id="saveManagerButton"
-            type="button"
-            data-testid="save-manager-button"
-            aria-label="Save manager"
-            title="Save manager"
-            disabled
-          >
-            <span class="icon" aria-hidden="true">💾</span>
-            <span class="label">Saves</span>
-          </button>
-          <button
-            id="helpButton"
-            type="button"
-            data-testid="help-button"
-            aria-label="Help &amp; shortcuts"
-            title="Help &amp; shortcuts"
-          >
-            <span class="icon" aria-hidden="true">ℹ</span>
-            <span class="label">Help</span>
-          </button>
-          <button
-            id="settingsButton"
-            type="button"
-            data-testid="settings-button"
-            aria-label="Settings"
-            title="Settings"
-          >
-            <span class="icon" aria-hidden="true">⚙</span>
-            <span class="label">Settings</span>
-          </button>
-        </div>
+        <button
+          id="hintButton"
+          type="button"
+          data-testid="hint-button"
+          aria-label="Hint"
+          title="Hint"
+          disabled
+        >
+          <span class="icon" aria-hidden="true">?</span>
+        </button>
+        <button
+          id="resetButton"
+          type="button"
+          data-testid="reset-button"
+          aria-label="Reset puzzle"
+          title="Reset puzzle"
+          disabled
+        >
+          <span class="icon" aria-hidden="true">↺</span>
+        </button>
+        <button
+          id="previewToggle"
+          type="button"
+          data-testid="preview-toggle"
+          aria-label="Show preview"
+          title="Show preview"
+          disabled
+        >
+          <span class="icon" aria-hidden="true">🖼</span>
+        </button>
+        <button
+          id="sampleCommand"
+          type="button"
+          data-testid="sample-art-button"
+          data-action="load-sample"
+          aria-label="Reload sample puzzle"
+          title="Reload sample puzzle"
+        >
+          <span class="icon" aria-hidden="true">🐹</span>
+        </button>
+        <button
+          id="fullscreenButton"
+          type="button"
+          data-testid="fullscreen-button"
+          aria-label="Enter fullscreen"
+          title="Enter fullscreen"
+        >
+          <span class="icon" aria-hidden="true">⛶</span>
+        </button>
+        <button
+          id="importButton"
+          type="button"
+          data-testid="import-button"
+          aria-label="Import"
+          title="Import"
+        >
+          <span class="icon" aria-hidden="true">⬆</span>
+        </button>
+        <button
+          id="saveManagerButton"
+          type="button"
+          data-testid="save-manager-button"
+          aria-label="Save manager"
+          title="Save manager"
+          disabled
+        >
+          <span class="icon" aria-hidden="true">💾</span>
+        </button>
+        <button
+          id="helpButton"
+          type="button"
+          data-testid="help-button"
+          aria-label="Help &amp; shortcuts"
+          title="Help &amp; shortcuts"
+        >
+          <span class="icon" aria-hidden="true">ℹ</span>
+        </button>
+        <button
+          id="settingsButton"
+          type="button"
+          data-testid="settings-button"
+          aria-label="Settings"
+          title="Settings"
+        >
+          <span class="icon" aria-hidden="true">⚙</span>
+        </button>
       </header>
       <div id="viewport">
         <div id="canvasStage">
@@ -1435,36 +1211,13 @@
         </div>
       </div>
       <footer id="paletteDock" aria-label="Palette dock" data-testid="palette-dock">
-        <div class="palette-meta">
-          <div
-            id="activeColorBadge"
-            class="active-color"
-            aria-live="polite"
-            data-has-colour="false"
-          >
-            <span class="active-swatch" data-active-color-swatch aria-hidden="true"></span>
-            <div class="active-info">
-              <span class="active-label">
-                <strong data-active-color-number>—</strong>
-              </span>
-              <p class="active-name" data-active-color-name>Pick a colour to start painting</p>
-              <p class="active-remaining" data-active-color-remaining>
-                Tap any swatch to highlight matching regions.
-              </p>
-            </div>
-          </div>
-          <div class="palette-controls">
-            <div id="progress" aria-live="polite" data-testid="progress-message">—</div>
-            <button
-              id="toggleCompletedColors"
-              type="button"
-              class="ghost"
-              aria-pressed="false"
-              title="Hide finished colours"
-            >
-              Hide finished colours
-            </button>
-          </div>
+        <div
+          id="progress"
+          aria-live="polite"
+          data-testid="progress-message"
+          data-status="idle"
+        >
+          Choose an artwork to start
         </div>
         <div id="palette" role="list"></div>
       </footer>
@@ -1499,9 +1252,8 @@
               </dd>
               <dt>🎚 Detail</dt>
               <dd>
-                Cycle the sample detail presets from the command rail or use the chips in the start hint and
-                Settings sheet to reload the demo with tuned palette sizes, minimum region areas, resize
-                targets, and the region counts noted above.
+                Toggle the capybara detail chips (start hint or Settings) to reload the sample with tuned
+                palette sizes, minimum region areas, resize targets, and the region counts noted above.
               </dd>
             <dt>⛶ Fullscreen</dt>
             <dd>Expand the app to fill the display or exit back to windowed mode.</dd>
@@ -1516,10 +1268,6 @@
               Adjust generation sliders, toggle auto-advance, customise the background, resize the interface, or export JSON.
               Expand Advanced options to edit the hidden art prompt metadata when you need to capture the original brief.
             </dd>
-            <dt>👁 Hide finished colours</dt>
-            <dd>
-              Collapse completed swatches from the palette dock to focus on remaining colours; toggle again to show the full set.
-            </dd>
           </dl>
         </section>
         <section class="sheet-section" aria-labelledby="controlsHeading">
@@ -1530,7 +1278,6 @@
             <li><kbd>Mouse wheel</kbd> or <kbd>+</kbd>/<kbd>-</kbd> Zoom in or out around the cursor.</li>
             <li><kbd>Space</kbd> + drag (or middle/right drag) Pan the canvas.</li>
             <li>Drag &amp; drop an image or JSON file anywhere on the window to import it.</li>
-            <li>Use the palette toggle to hide finished colours when you want a cleaner strip of remaining swatches.</li>
           </ul>
         </section>
         <section class="sheet-section" aria-labelledby="debugHeading">
@@ -1582,13 +1329,6 @@
           </label>
           <p class="control-note">
             Applies to unfinished regions and adjusts outline contrast automatically.
-          </p>
-          <label class="toggle">
-            <input id="hideCompletedToggle" type="checkbox" />
-            <span>Hide finished colours in the palette</span>
-          </label>
-          <p class="control-note">
-            Completed swatches disappear until you show them again; the active colour stays visible.
           </p>
           <label class="control">
             <span>Interface scale <output data-for="uiScale">100%</output></span>
@@ -1690,7 +1430,6 @@
       const sampleDetailButtons = Array.from(document.querySelectorAll('[data-detail-level]'));
       const sampleDetailCaptions = Array.from(document.querySelectorAll('[data-detail-caption]'));
       const samplePreview = document.getElementById("sampleArtPreview");
-      const detailCycleButton = document.getElementById("detailCycleButton");
       const startHint = document.getElementById("startHint");
       const hintButton = document.getElementById("hintButton");
       const resetButton = document.getElementById("resetButton");
@@ -1715,7 +1454,6 @@
       const cursorNumberEl = cursorOverlay?.querySelector("[data-pointer-number]") || null;
       const autoAdvanceToggle = document.getElementById("autoAdvanceToggle");
       const hintFlashToggle = document.getElementById("hintFlashToggle");
-      const hideCompletedToggle = document.getElementById("hideCompletedToggle");
       const backgroundColorInput = document.getElementById("backgroundColor");
       const uiScaleInput = document.getElementById("uiScale");
       const colorCountEl = document.getElementById("colorCount");
@@ -1731,13 +1469,13 @@
       const saveList = document.getElementById("saveList");
       const paletteEl = document.getElementById("palette");
       const progressEl = document.getElementById("progress");
-      const toggleCompletedButton = document.getElementById("toggleCompletedColors");
-      const activeColorBadge = document.getElementById("activeColorBadge");
-      const activeColorSwatch = activeColorBadge?.querySelector("[data-active-color-swatch]") || null;
-      const activeColorNumberEl = activeColorBadge?.querySelector("[data-active-color-number]") || null;
-      const activeColorNameEl = activeColorBadge?.querySelector("[data-active-color-name]") || null;
-      const activeColorRemainingEl =
-        activeColorBadge?.querySelector("[data-active-color-remaining]") || null;
+      const PROGRESS_MESSAGES = {
+        idle: "Choose an artwork to start",
+        loading: "Loading puzzle…",
+        ready: "Ready to colour",
+        active: "Keep colouring",
+        complete: "All done!",
+      };
       const puzzleCanvas = document.getElementById("puzzleCanvas");
       const previewCanvas = document.getElementById("previewCanvas");
       const puzzleCtx = puzzleCanvas.getContext("2d");
@@ -1778,6 +1516,7 @@
 
       function installBrowserZoomGuards() {
         if (typeof window === "undefined") return;
+        if (preventingBrowserZoom) return;
         let lastTouchEndTime = 0;
         const isGameSurface = (node) => {
           if (!(node instanceof Node)) return false;
@@ -1820,8 +1559,11 @@
           (event) => {
             if (!event) return;
             if (!event.ctrlKey && !event.metaKey) return;
-            if (isInteractiveElementForZoomGuard(event.target)) return;
-            if (isGameSurface(event.target)) return;
+            const isInteractive = isInteractiveElementForZoomGuard(event.target);
+            const isStageTarget = isGameSurface(event.target);
+            if (isInteractive || isStageTarget) {
+              return;
+            }
             event.preventDefault();
           },
           { passive: false, capture: true }
@@ -1833,7 +1575,8 @@
             if (!event) return;
             if (!event.ctrlKey && !event.metaKey) return;
             if (event.altKey) return;
-            if (isInteractiveElementForZoomGuard(event.target)) return;
+            const isInteractive = isInteractiveElementForZoomGuard(event.target);
+            if (isInteractive) return;
             const key = event.key;
             const code = event.code;
             const wantsReset = key === "0" || code === "Digit0" || code === "Numpad0";
@@ -1973,7 +1716,6 @@
           backgroundColor: DEFAULT_BACKGROUND_HEX,
           uiScale: 1,
           artPrompt: "",
-          hideCompletedColors: false,
         },
         previewVisible: false,
         saves: loadSavedEntries(),
@@ -1994,13 +1736,6 @@
           if (hintFlashToggle) {
             hintFlashToggle.checked = settings.animateHints;
           }
-        }
-        if (typeof settings.hideCompletedColors === "boolean") {
-          applyHideCompletedColors(settings.hideCompletedColors, {
-            skipLog: true,
-            skipAutosave: true,
-            skipRender: true,
-          });
         }
         if (typeof settings.uiScale === "number") {
           applyUiScale(settings.uiScale, { skipLog: true, skipAutosave: true });
@@ -2091,19 +1826,6 @@
         });
       }
 
-      if (detailCycleButton) {
-        detailCycleButton.addEventListener("click", () => {
-          const order = Object.keys(SAMPLE_DETAIL_LEVELS);
-          const currentId =
-            state.sampleDetailLevel && SAMPLE_DETAIL_LEVELS[state.sampleDetailLevel]
-              ? state.sampleDetailLevel
-              : DEFAULT_SAMPLE_DETAIL;
-          const currentIndex = Math.max(0, order.indexOf(currentId));
-          const nextId = order[(currentIndex + 1) % order.length];
-          applySampleDetailLevel(nextId);
-        });
-      }
-
       applySampleDetailLevel(DEFAULT_SAMPLE_DETAIL, { skipReload: true, skipLog: true });
 
       const restoredSession = loadInitialSession();
@@ -2118,16 +1840,6 @@
       if (helpButton) {
         helpButton.addEventListener("click", () => openSheet(helpSheet));
       }
-
-      if (toggleCompletedButton) {
-        toggleCompletedButton.addEventListener("click", () => {
-          applyHideCompletedColors(!state.settings.hideCompletedColors);
-        });
-      }
-
-      updateHideCompletedButton();
-      updateActiveColorBadge(null);
-      updateDetailCycleButtonState();
 
       if (fullscreenButton) {
         fullscreenButton.addEventListener("click", () => toggleFullscreen());
@@ -2191,12 +1903,6 @@
         scheduleAutosave("settings-hint-animations");
       });
 
-      if (hideCompletedToggle) {
-        hideCompletedToggle.addEventListener("change", (event) => {
-          applyHideCompletedColors(Boolean(event.target.checked));
-        });
-      }
-
       if (backgroundColorInput) {
         backgroundColorInput.addEventListener("input", (event) => {
           applyBackgroundColor(event.target.value, { skipLog: true, skipAutosave: true });
@@ -2242,6 +1948,10 @@
         scheduleAutosave("reset-progress");
         logDebug("Reset puzzle progress");
       });
+
+      if (paletteEl) {
+        paletteEl.addEventListener("wheel", handlePaletteWheel, { passive: false });
+      }
 
       previewToggle.addEventListener("click", () => {
         state.previewVisible = !state.previewVisible;
@@ -2614,12 +2324,8 @@
         document.documentElement.style.setProperty("--ui-scale-auto", autoScale.toFixed(3));
         if (document.body) {
           document.body.dataset.orientation = orientation;
-          const compactCommands = visualWidth < 720 || visualHeight < 540;
-          const compactPalette = visualHeight < 600 || visualWidth < 880;
-          const showLabels = visualWidth >= 1280 && visualHeight >= 720;
-          document.body.classList.toggle("compact-commands", compactCommands);
-          document.body.classList.toggle("compact-palette", compactPalette);
-          document.body.classList.toggle("show-command-labels", showLabels);
+          const compact = visualWidth < 720 || visualHeight < 540;
+          document.body.classList.toggle("compact-commands", compact);
         }
         syncComputedUiScale();
         const changed = orientation !== lastViewportMetrics.orientation;
@@ -2642,30 +2348,6 @@
           resetView({ preserveZoom: true, recenter: recenter || orientationChanged });
         }
         hideCustomCursor();
-      }
-
-      function updateDetailCycleButtonState() {
-        if (!detailCycleButton) return;
-        const activeConfig =
-          SAMPLE_DETAIL_LEVELS[state.sampleDetailLevel] || SAMPLE_DETAIL_LEVELS[DEFAULT_SAMPLE_DETAIL];
-        const labelEl = detailCycleButton.querySelector("[data-detail-label]");
-        if (labelEl) {
-          labelEl.textContent = activeConfig?.shortLabel || activeConfig?.label || "Detail";
-        }
-        const order = Object.keys(SAMPLE_DETAIL_LEVELS);
-        const currentId = activeConfig?.id || DEFAULT_SAMPLE_DETAIL;
-        const currentIndex = Math.max(0, order.indexOf(currentId));
-        const nextId = order[(currentIndex + 1) % order.length];
-        const nextConfig = SAMPLE_DETAIL_LEVELS[nextId];
-        const summary = activeConfig?.summary || activeConfig?.label || "Detail presets";
-        const nextLabel = nextConfig?.label || nextConfig?.summary || nextId;
-        const aria = nextLabel
-          ? `${summary} active. Next: ${nextLabel}.`
-          : `${summary} active.`;
-        detailCycleButton.setAttribute("aria-label", aria);
-        detailCycleButton.title = nextLabel
-          ? `Cycle detail presets (next: ${nextLabel})`
-          : "Cycle detail presets";
       }
 
       function applySampleDetailLevel(level, options = {}) {
@@ -2692,7 +2374,6 @@
             caption.textContent = config.summary;
           }
         }
-        updateDetailCycleButtonState();
         for (const button of sampleButtons) {
           if (!button) continue;
           const labelBase = `Reload ${SAMPLE_ARTWORK.title}`;
@@ -2910,83 +2591,6 @@
         return normalized;
       }
 
-      function updateHideCompletedButton() {
-        if (!toggleCompletedButton) return;
-        const active = Boolean(state.settings.hideCompletedColors);
-        toggleCompletedButton.classList.toggle("active", active);
-        toggleCompletedButton.setAttribute("aria-pressed", active ? "true" : "false");
-        const label = active ? "Show finished colours" : "Hide finished colours";
-        toggleCompletedButton.textContent = active ? "Show all colours" : "Hide finished colours";
-        toggleCompletedButton.title = label;
-        toggleCompletedButton.setAttribute("aria-label", label);
-      }
-
-      function updateActiveColorBadge(stats = null) {
-        if (!activeColorBadge) return;
-        const hasColour = Boolean(stats && stats.paletteEntry);
-        activeColorBadge.dataset.hasColour = hasColour ? "true" : "false";
-        if (!hasColour) {
-          if (activeColorSwatch) {
-            activeColorSwatch.style.removeProperty("--active-color");
-          }
-          if (activeColorNumberEl) {
-            activeColorNumberEl.textContent = "—";
-          }
-          if (activeColorNameEl) {
-            activeColorNameEl.textContent = "Pick a colour to start painting";
-          }
-          if (activeColorRemainingEl) {
-            activeColorRemainingEl.textContent = "Tap any swatch to highlight matching regions.";
-          }
-          return;
-        }
-        const { paletteEntry, total = 0, remaining = 0 } = stats;
-        if (activeColorSwatch) {
-          if (paletteEntry?.hex) {
-            activeColorSwatch.style.setProperty("--active-color", paletteEntry.hex);
-          } else {
-            activeColorSwatch.style.removeProperty("--active-color");
-          }
-        }
-        if (activeColorNumberEl) {
-          activeColorNumberEl.textContent = `#${paletteEntry.id}`;
-        }
-        if (activeColorNameEl) {
-          activeColorNameEl.textContent = paletteEntry.name || `Colour ${paletteEntry.id}`;
-        }
-        if (activeColorRemainingEl) {
-          const message =
-            remaining > 0
-              ? `${remaining} of ${total} regions unfinished`
-              : `All ${total} regions complete`;
-          activeColorRemainingEl.textContent = message;
-        }
-      }
-
-      function applyHideCompletedColors(value, options = {}) {
-        const { skipLog = false, skipAutosave = false, skipRender = false } = options;
-        const resolved = Boolean(value);
-        const previous = Boolean(state.settings.hideCompletedColors);
-        state.settings.hideCompletedColors = resolved;
-        if (paletteEl) {
-          paletteEl.classList.toggle("hide-complete", resolved);
-        }
-        if (hideCompletedToggle && hideCompletedToggle.checked !== resolved) {
-          hideCompletedToggle.checked = resolved;
-        }
-        updateHideCompletedButton();
-        if (!skipRender && previous !== resolved) {
-          renderPalette();
-        }
-        if (previous !== resolved && !skipLog) {
-          logDebug(resolved ? "Hiding completed colours from palette" : "Showing all palette colours");
-        }
-        if (previous !== resolved && !skipAutosave) {
-          scheduleAutosave("settings-hide-complete");
-        }
-        return resolved;
-      }
-
       function updateOptionOutputs() {
         if (optionOutputs.colorCount) optionOutputs.colorCount.textContent = String(colorCountEl.value);
         if (optionOutputs.minRegion) optionOutputs.minRegion.textContent = `${minRegionEl.value} px²`;
@@ -3047,22 +2651,28 @@
               const fallbackTitle = file.name || "Imported puzzle";
               const resolvedTitle = providedTitle || fallbackTitle;
               state.sourceTitle = resolvedTitle;
-              if (
-                applyPuzzleResult(payload, {
-                  options: payload.options || getCurrentOptions(),
-                  filled: payload.filled,
-                  activeColor: payload.activeColor,
-                  backgroundColor: payload.backgroundColor,
-                  title: resolvedTitle,
-                })
-              ) {
+              const applied = applyPuzzleResult(payload, {
+                options: payload.options || getCurrentOptions(),
+                filled: payload.filled,
+                activeColor: payload.activeColor,
+                backgroundColor: payload.backgroundColor,
+                title: resolvedTitle,
+              });
+              if (applied) {
                 startHint.classList.add("hidden");
                 state.sourceUrl = payload.sourceUrl || null;
                 logDebug(`Imported puzzle from JSON: ${resolvedTitle}`);
+              } else {
+                setProgressMessage("idle");
               }
             } catch (error) {
               console.error(error);
+              setProgressMessage("idle");
             }
+          };
+          reader.onerror = () => {
+            console.error("Unable to read that file.");
+            setProgressMessage("idle");
           };
           reader.readAsText(file);
           return;
@@ -3079,10 +2689,12 @@
             loadImage(result);
           } else {
             console.error("Unsupported file format");
+            setProgressMessage("idle");
           }
         };
         reader.onerror = () => {
           console.error("Unable to read that file.");
+          setProgressMessage("idle");
         };
         reader.readAsDataURL(file);
       }
@@ -3099,19 +2711,24 @@
             const options = getCurrentOptions();
             const data = await createPuzzleData(img, options);
             const title = state.sourceTitle || "Generated puzzle";
-            applyPuzzleResult(data, {
+            const applied = applyPuzzleResult(data, {
               options,
               title,
               backgroundColor: state.settings.backgroundColor,
               logMessage: completionMessage,
               skipDefaultLog,
             });
+            if (!applied) {
+              setProgressMessage("idle");
+            }
           } catch (error) {
             console.error("Failed to create puzzle", error);
+            setProgressMessage("idle");
           }
         };
         img.onerror = () => {
           console.error("Unable to read that image.");
+          setProgressMessage("idle");
         };
         img.src = url;
       }
@@ -3127,15 +2744,8 @@
         state.filled = new Set();
         state.sourceUrl = null;
         state.sourceTitle = null;
-        if (paletteEl) {
-          paletteEl.innerHTML = "";
-          paletteEl.classList.toggle("hide-complete", Boolean(state.settings.hideCompletedColors));
-        }
-        if (progressEl) {
-          progressEl.textContent = "…";
-        }
-        updateActiveColorBadge(null);
-        updateHideCompletedButton();
+        paletteEl.innerHTML = "";
+        setProgressMessage("loading");
         puzzleCtx.clearRect(0, 0, puzzleCanvas.width, puzzleCanvas.height);
         previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
         state.previewImageData = null;
@@ -3203,10 +2813,12 @@
       function applyPuzzleResult(data, metadata = {}) {
         if (!data || typeof data.width !== "number" || typeof data.height !== "number") {
           console.error("Puzzle data missing required dimensions.");
+          setProgressMessage("idle");
           return false;
         }
         if (!Array.isArray(data.palette) || !Array.isArray(data.regions)) {
           console.error("Puzzle data missing palette information.");
+          setProgressMessage("idle");
           return false;
         }
         const expectedCells = data.width * data.height;
@@ -3215,6 +2827,7 @@
           unpackRegionMap(data.regionMap, expectedCells);
         if (!regionMapSource || regionMapSource.length !== expectedCells) {
           console.error("Puzzle data is inconsistent.");
+          setProgressMessage("idle");
           return false;
         }
         let needsPixelHydration = false;
@@ -3326,16 +2939,6 @@
         const resolvedSettings = metadata.settings ?? data.settings;
         if (resolvedSettings) {
           applyGameplaySettings(resolvedSettings);
-        }
-        const resolvedDetailLevel = metadata.sampleDetailLevel ?? data.sampleDetailLevel;
-        if (resolvedDetailLevel) {
-          applySampleDetailLevel(resolvedDetailLevel, {
-            skipReload: true,
-            skipLog: true,
-            skipOptions: true,
-          });
-        } else {
-          updateDetailCycleButtonState();
         }
         applyBackgroundColor(backgroundHex, { skipRender: true, skipLog: true });
         puzzleCanvas.width = data.width;
@@ -3856,14 +3459,8 @@
       }
 
       function renderPalette() {
-        if (!paletteEl) return;
         paletteEl.innerHTML = "";
-        paletteEl.classList.toggle("hide-complete", Boolean(state.settings.hideCompletedColors));
-        if (!state.puzzle) {
-          updateActiveColorBadge(null);
-          updateHideCompletedButton();
-          return;
-        }
+        if (!state.puzzle) return;
         const totalByColor = new Map();
         const remainingByColor = new Map();
         for (const region of state.puzzle.regions) {
@@ -3904,29 +3501,55 @@
           });
           paletteEl.appendChild(swatch);
         }
-        const activeId = state.activeColor;
-        const paletteEntry =
-          activeId != null ? state.puzzle.palette.find((entry) => entry.id === activeId) || null : null;
-        const stats =
-          paletteEntry && paletteEntry.id != null
-            ? {
-                paletteEntry,
-                total: totalByColor.get(paletteEntry.id) || 0,
-                remaining: remainingByColor.get(paletteEntry.id) || 0,
-              }
-            : null;
-        updateActiveColorBadge(stats);
-        updateHideCompletedButton();
+      }
+
+      function handlePaletteWheel(event) {
+        if (!paletteEl) return;
+        if (event.defaultPrevented) return;
+        if (event.ctrlKey || event.metaKey || event.shiftKey) {
+          return;
+        }
+        const { deltaX, deltaY, deltaMode } = event;
+        if (Math.abs(deltaX) >= Math.abs(deltaY) || deltaY === 0) {
+          return;
+        }
+        event.preventDefault();
+        const WHEEL_DELTA_LINE = 1;
+        const WHEEL_DELTA_PAGE = 2;
+        let delta = deltaY;
+        if (deltaMode === WHEEL_DELTA_LINE) {
+          delta *= 24;
+        } else if (deltaMode === WHEEL_DELTA_PAGE) {
+          delta *= paletteEl.clientWidth;
+        }
+        paletteEl.scrollLeft += delta;
+      }
+
+      function setProgressMessage(status) {
+        const message = PROGRESS_MESSAGES[status] || PROGRESS_MESSAGES.idle;
+        if (!progressEl) return;
+        progressEl.textContent = message;
+        progressEl.setAttribute("data-status", status || "idle");
       }
 
       function updateProgress() {
         if (!state.puzzle) {
-          progressEl.textContent = "—";
+          setProgressMessage("idle");
           return;
         }
         const total = state.puzzle.regions.length;
         const done = state.filled.size;
-        progressEl.textContent = `${done}/${total}`;
+        if (!total || total <= 0) {
+          setProgressMessage("ready");
+          return;
+        }
+        if (done >= total) {
+          setProgressMessage("complete");
+        } else if (done === 0) {
+          setProgressMessage("ready");
+        } else {
+          setProgressMessage("active");
+        }
       }
 
       function handleKeyDown(event) {
@@ -4601,9 +4224,7 @@
             animateHints: Boolean(state.settings.animateHints),
             uiScale: Number(state.settings.uiScale) || 1,
             artPrompt: state.settings.artPrompt || "",
-            hideCompletedColors: Boolean(state.settings.hideCompletedColors),
           },
-          sampleDetailLevel: state.sampleDetailLevel,
         };
         if (regionMapPacked) {
           payload.regionMapPacked = regionMapPacked;

--- a/tests/ui-review.spec.js
+++ b/tests/ui-review.spec.js
@@ -2,38 +2,468 @@ const { test, expect } = require('@playwright/test');
 
 const APP_URL = 'http://127.0.0.1:8000/index.html';
 
-test.describe('Capy smoke tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
-  });
+const BASIC_TEST_PATTERN = {
+  name: 'Basic test pattern',
+  width: 4,
+  height: 4,
+  palette: [
+    { id: 1, hex: '#e11d48', rgba: [225, 29, 72] },
+    { id: 2, hex: '#22c55e', rgba: [34, 197, 94] },
+  ],
+  regions: [
+    { id: 0, colorId: 1, pixels: [0, 1, 4, 5], pixelCount: 4, cx: 0.5, cy: 0.5 },
+    { id: 1, colorId: 2, pixels: [2, 3, 6, 7], pixelCount: 4, cx: 2.5, cy: 0.5 },
+    { id: 2, colorId: 1, pixels: [8, 9, 12, 13], pixelCount: 4, cx: 0.5, cy: 2.5 },
+    { id: 3, colorId: 2, pixels: [10, 11, 14, 15], pixelCount: 4, cx: 2.5, cy: 2.5 },
+  ],
+  regionMap: [
+    0, 0, 1, 1,
+    0, 0, 1, 1,
+    2, 2, 3, 3,
+    2, 2, 3, 3,
+  ],
+};
 
-  test('shows the palette and hides the onboarding hint after load', async ({ page }) => {
+async function loadBasicTestPattern(page) {
+  await page.evaluate((puzzle) => {
+    window.capyGenerator.loadPuzzleFixture(puzzle);
+  }, BASIC_TEST_PATTERN);
+  await page.waitForSelector('[data-testid="palette-swatch"]');
+  await expect(page.locator('[data-testid="start-hint"]')).toHaveClass(/hidden/);
+}
+
+async function clickRegionCenter(page, region, puzzle) {
+  expect(region.pixels.length).toBeGreaterThan(0);
+  const sample = region.pixels[0];
+  await page.evaluate(({ pixel, width, height }) => {
+    const canvas = document.querySelector('[data-testid="puzzle-canvas"]');
+    if (!canvas) return;
+    const state = window.capyGenerator.getState();
+    if (!state.puzzle) return;
+    const pixelX = pixel % width;
+    const pixelY = Math.floor(pixel / width);
+    const rect = canvas.getBoundingClientRect();
+    const clientX = rect.left + ((pixelX + 0.5) / width) * rect.width;
+    const clientY = rect.top + ((pixelY + 0.5) / height) * rect.height;
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX,
+      clientY,
+    });
+    canvas.dispatchEvent(event);
+  }, { pixel: sample, width: puzzle.width, height: puzzle.height });
+}
+
+async function getStageFlashValue(page) {
+  return page.evaluate(() => {
+    const stage = document.querySelector('#canvasStage');
+    return stage?.dataset.flashingColor || null;
+  });
+}
+
+test.describe('Capy image generator', () => {
+  test('renders command rail and hidden generator settings on load', async ({ page }) => {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('[data-testid="palette-swatch"]');
     await expect(page.locator('[data-testid="start-hint"]')).toHaveClass(/hidden/);
 
-    const state = await page.evaluate(() => {
-      const generator = window.capyGenerator?.getState?.();
+    const layout = await page.evaluate(() => {
+      const progress = document.querySelector('[data-testid="progress-message"]');
+      const commandButtons = Array.from(document.querySelectorAll('#commandRail button')).map(
+        (el) => el.getAttribute('aria-label') || el.getAttribute('title') || (el.textContent || '').trim()
+      );
+      const hasSettings = Boolean(document.querySelector('#settingsSheet'));
+      const hasSampleButton = Boolean(document.querySelector('[data-testid="sample-art-button"]'));
+      const viewportMeta = document
+        .querySelector('meta[name="viewport"]')
+        ?.getAttribute('content');
+      const zoomGuardActive =
+        typeof window.capyGenerator?.isBrowserZoomSuppressed === 'function' &&
+        window.capyGenerator.isBrowserZoomSuppressed();
       return {
-        hasPuzzle: Boolean(generator?.puzzle),
-        paletteCount: generator?.puzzle?.palette?.length ?? 0,
+        progress: (progress?.textContent || '').trim(),
+        commandButtons,
+        hasSettings,
+        hasSampleButton,
+        orientation: document.body?.dataset.orientation || null,
+        viewportMeta,
+        zoomGuardActive,
+      };
+    });
+
+    expect(layout.hasSettings).toBe(true);
+    expect(layout.progress).toBe('Ready to colour');
+    expect(layout.hasSampleButton).toBe(true);
+    expect(layout.orientation).toMatch(/landscape|portrait/);
+    expect(layout.viewportMeta || '').toMatch(/user-scalable=no/);
+    expect(layout.zoomGuardActive).toBe(true);
+    expect(layout.commandButtons).toEqual(
+      expect.arrayContaining([
+        'Hint',
+        'Reset puzzle',
+        'Show preview',
+        expect.stringContaining('Reload Capybara Springs'),
+        'Enter fullscreen',
+        'Import',
+        'Save manager',
+        'Help & shortcuts',
+        'Settings',
+      ])
+    );
+
+    await page.click('#helpButton');
+    await expect(page.locator('#helpSheet')).toBeVisible();
+
+    const helpLegend = await page.$$eval('#helpSheet .command-list dt', (nodes) =>
+      nodes.map((node) => (node.textContent || '').trim())
+    );
+    expect(helpLegend).toEqual(
+      expect.arrayContaining(['? Hint', '🖼 Preview', '🐹 Sample', '🎚 Detail', '⛶ Fullscreen', 'ℹ Help', '⚙ Settings'])
+    );
+
+    const logMessages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+      nodes.map((el) => (el.textContent || '').trim())
+    );
+    expect(logMessages.some((message) => message.includes('Session started'))).toBe(true);
+    expect(logMessages.some((message) => message.includes('Orientation changed'))).toBe(true);
+
+    await page.click('[data-sheet-close="help"]');
+
+    await page.click('#settingsButton');
+    const generatorLabels = await page.$$eval(
+      '#settingsSheet label span:first-child',
+      (nodes) => nodes.map((el) => (el.textContent || '').trim())
+    );
+    expect(generatorLabels.some((label) => label.includes('Colours'))).toBe(true);
+    expect(generatorLabels.some((label) => label.includes('Sample rate'))).toBe(true);
+    expect(generatorLabels.some((label) => label.includes('Background colour'))).toBe(true);
+    expect(generatorLabels.some((label) => label.includes('Interface scale'))).toBe(true);
+
+    const artPrompt = page.locator('#artPrompt');
+    await expect(artPrompt).toBeHidden();
+    await page.click('#generatorAdvanced summary');
+    await expect(artPrompt).toBeVisible();
+    await page.click('#generatorAdvanced summary');
+    await expect(artPrompt).toBeHidden();
+    await page.click('[data-sheet-close="settings"]');
+  });
+
+  test('auto loads and reloads the capybara sample scene', async ({ page }) => {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-testid="palette-swatch"]');
+    await expect(page.locator('[data-testid="start-hint"]')).toHaveClass(/hidden/);
+
+    const detailButtons = page.locator('[data-detail-level]');
+    await expect(detailButtons).toHaveCount(6);
+    await expect(page.locator('#startHint [data-detail-level]')).toHaveCount(3);
+    await expect(page.locator('#settingsSheet [data-detail-level]')).toHaveCount(3);
+    await expect(page.locator('#startHint [data-detail-level="high"]')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(page.locator('#settingsSheet [data-detail-level="high"]')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    const detailCaption = page.locator('[data-detail-caption]').first();
+    await expect(detailCaption).toHaveText(/High detail/i);
+    const progress = page.locator('[data-testid="progress-message"]');
+    await expect(progress).toHaveText('Ready to colour');
+
+    const state = await page.evaluate(() => {
+      const { puzzle, sourceUrl, sampleDetailLevel, lastOptions } = window.capyGenerator.getState();
+      return {
+        hasPuzzle: Boolean(puzzle),
+        regionCount: puzzle?.regions?.length || 0,
+        paletteCount: puzzle?.palette?.length || 0,
+        sourceUrl,
+        detailLevel: sampleDetailLevel,
+        targetColors: lastOptions?.targetColors || null,
       };
     });
 
     expect(state.hasPuzzle).toBe(true);
-    expect(state.paletteCount).toBeGreaterThan(0);
-  });
+    expect(state.paletteCount).toBe(32);
+    expect(state.regionCount).toBeGreaterThanOrEqual(120);
+    expect(state.regionCount).toBeLessThanOrEqual(190);
+    expect(state.sourceUrl).toContain('data:image/svg+xml;base64,');
+    expect(state.detailLevel).toBe('high');
+    expect(state.targetColors).toBe(32);
 
-  test('opens and closes the help and settings sheets', async ({ page }) => {
-    await page.click('#helpButton');
-    const helpSheet = page.locator('#helpSheet');
-    await expect(helpSheet).toBeVisible();
-    await page.click('[data-sheet-close="help"]');
-    await expect(helpSheet).toHaveClass(/hidden/);
+    await page.click('[data-testid="sample-art-button"]');
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Loading high detail sample puzzle/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /High detail sample puzzle ready/.test(message));
+      })
+      .toBe(true);
 
     await page.click('#settingsButton');
-    const settingsSheet = page.locator('#settingsSheet');
-    await expect(settingsSheet).toBeVisible();
+    await expect(page.locator('#settingsSheet')).toBeVisible();
+
+    await page.click('#settingsSheet [data-detail-level="medium"]');
+    await expect.poll(() =>
+      page.evaluate(() => window.capyGenerator.getState().sampleDetailLevel)
+    ).toBe('medium');
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Loading medium detail sample puzzle/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Medium detail sample puzzle ready/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.capyGenerator.getState().puzzle?.palette?.length || 0)
+      )
+      .toBeGreaterThan(0);
+    const mediumState = await page.evaluate(() => {
+      const { puzzle, sampleDetailLevel, lastOptions } = window.capyGenerator.getState();
+      return {
+        detailLevel: sampleDetailLevel,
+        paletteCount: puzzle?.palette?.length || 0,
+        regionCount: puzzle?.regions?.length || 0,
+        targetColors: lastOptions?.targetColors || null,
+      };
+    });
+    expect(mediumState.detailLevel).toBe('medium');
+    expect(mediumState.paletteCount).toBe(26);
+    expect(mediumState.targetColors).toBe(26);
+    expect(mediumState.regionCount).toBeGreaterThanOrEqual(38);
+    expect(mediumState.regionCount).toBeLessThanOrEqual(60);
+
+    await page.click('#settingsSheet [data-detail-level="high"]');
+    await expect.poll(() =>
+      page.evaluate(() => window.capyGenerator.getState().sampleDetailLevel)
+    ).toBe('high');
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Loading high detail sample puzzle/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /High detail sample puzzle ready/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.capyGenerator.getState().puzzle?.palette?.length || 0)
+      )
+      .toBeGreaterThan(0);
+    const highState = await page.evaluate(() => {
+      const { puzzle, sampleDetailLevel, lastOptions } = window.capyGenerator.getState();
+      return {
+        detailLevel: sampleDetailLevel,
+        paletteCount: puzzle?.palette?.length || 0,
+        regionCount: puzzle?.regions?.length || 0,
+        targetColors: lastOptions?.targetColors || null,
+      };
+    });
+    expect(highState.detailLevel).toBe('high');
+    expect(highState.paletteCount).toBe(32);
+    expect(highState.targetColors).toBe(32);
+    expect(highState.regionCount).toBeGreaterThanOrEqual(120);
+    expect(highState.regionCount).toBeLessThanOrEqual(190);
+
+    await page.click('#settingsSheet [data-detail-level="low"]');
+    await expect.poll(() =>
+      page.evaluate(() => window.capyGenerator.getState().sampleDetailLevel)
+    ).toBe('low');
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Loading low detail sample puzzle/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(async () => {
+        const messages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+          nodes.map((el) => (el.textContent || '').trim())
+        );
+        return messages.some((message) => /Low detail sample puzzle ready/.test(message));
+      })
+      .toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.capyGenerator.getState().puzzle?.palette?.length || 0)
+      )
+      .toBeGreaterThan(0);
+    const lowState = await page.evaluate(() => {
+      const { puzzle, sampleDetailLevel, lastOptions } = window.capyGenerator.getState();
+      return {
+        detailLevel: sampleDetailLevel,
+        paletteCount: puzzle?.palette?.length || 0,
+        regionCount: puzzle?.regions?.length || 0,
+        targetColors: lastOptions?.targetColors || null,
+      };
+    });
+    expect(lowState.detailLevel).toBe('low');
+    expect(lowState.paletteCount).toBe(18);
+    expect(lowState.targetColors).toBe(18);
+    expect(lowState.regionCount).toBeGreaterThanOrEqual(20);
+    expect(lowState.regionCount).toBeLessThanOrEqual(40);
+
     await page.click('[data-sheet-close="settings"]');
-    await expect(settingsSheet).toHaveClass(/hidden/);
+  });
+
+  test('flashes matching regions and supports zoom controls', async ({ page }) => {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+    await loadBasicTestPattern(page);
+
+    await expect.poll(() => getStageFlashValue(page)).toBeNull();
+
+    await page.click('[data-color-id="1"]');
+    await expect.poll(() => getStageFlashValue(page)).toBe('1');
+    await expect.poll(() => getStageFlashValue(page)).toBeNull();
+
+    const zoomValue = () =>
+      page.evaluate(() =>
+        parseFloat(
+          getComputedStyle(document.querySelector('#canvasTransform')).getPropertyValue('--zoom')
+        )
+      );
+
+    const initialZoom = await zoomValue();
+    await page.evaluate(() => {
+      const canvas = document.querySelector('[data-testid="puzzle-canvas"]');
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const event = new WheelEvent('wheel', {
+        deltaX: 0,
+        deltaY: -240,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      });
+      canvas.dispatchEvent(event);
+    });
+    await expect.poll(zoomValue).toBeGreaterThan(initialZoom);
+    const afterWheel = await zoomValue();
+
+    await page.keyboard.press('Minus');
+    await expect.poll(zoomValue).toBeLessThan(afterWheel);
+    const afterMinus = await zoomValue();
+
+    await page.keyboard.press('Shift+=');
+    await expect.poll(zoomValue).toBeGreaterThan(afterMinus);
+
+    await page.click('#helpButton');
+    const logMessages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+      nodes.map((el) => (el.textContent || '').trim())
+    );
+    expect(logMessages.length).toBeGreaterThan(0);
+    expect(logMessages[0]).toMatch(/Zoom set to/);
+    expect(logMessages.some((message) => message.includes('colour #1'))).toBe(true);
+    await page.click('[data-sheet-close="help"]');
+  });
+
+  test('allows adjusting the canvas background colour', async ({ page }) => {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+    await loadBasicTestPattern(page);
+
+    await page.evaluate(() => {
+      window.capyGenerator.setBackgroundColor('#1e293b');
+      window.capyGenerator.setUiScale(1.2);
+      window.capyGenerator.setArtPrompt('Capybara springs remake');
+    });
+
+    const state = await page.evaluate(() => window.capyGenerator.getState());
+    expect(state.settings.backgroundColor).toBe('#1e293b');
+    expect(state.settings.uiScale).toBeCloseTo(1.2, 2);
+    expect(state.settings.artPrompt).toBe('Capybara springs remake');
+
+    const pixel = await page.evaluate(() => {
+      const canvas = document.querySelector('[data-testid="puzzle-canvas"]');
+      if (!canvas) return null;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+      return Array.from(ctx.getImageData(0, 0, 1, 1).data);
+    });
+    expect(pixel).not.toBeNull();
+    expect(pixel.slice(0, 3)).not.toEqual([248, 250, 252]);
+
+    const dataPixel = await page.evaluate(() => {
+      const state = window.capyGenerator.getState();
+      if (!state.puzzleImageData) return null;
+      return Array.from(state.puzzleImageData.data.slice(0, 3));
+    });
+    expect(dataPixel).toEqual([30, 41, 59]);
+
+    await page.click('#helpButton');
+    const logMessages = await page.$$eval('#debugLog .log-entry span', (nodes) =>
+      nodes.map((el) => (el.textContent || '').trim())
+    );
+    expect(logMessages.some((message) => /Background colour set to #1E293B/.test(message))).toBe(true);
+    expect(logMessages.some((message) => /Interface scale set to 120%/.test(message))).toBe(true);
+    expect(logMessages.some((message) => /Art prompt updated \(\d+ characters\)/.test(message))).toBe(true);
+    await page.click('[data-sheet-close="help"]');
+  });
+
+  test('fills the basic test pattern to completion', async ({ page }) => {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+    await loadBasicTestPattern(page);
+
+    const palette = page.locator('[data-testid="palette-swatch"]');
+    await expect(palette).toHaveCount(BASIC_TEST_PATTERN.palette.length);
+    await page.click('#settingsButton');
+    await expect(page.locator('#downloadJson')).toBeEnabled();
+    await page.click('[data-sheet-close="settings"]');
+    await expect(page.locator('#resetButton')).toBeEnabled();
+
+    const progress = page.locator('[data-testid="progress-message"]');
+    await expect(progress).toHaveText('Ready to colour');
+
+    for (let index = 0; index < BASIC_TEST_PATTERN.regions.length; index += 1) {
+      const region = BASIC_TEST_PATTERN.regions[index];
+      await page.click(`[data-color-id="${region.colorId}"]`);
+      await clickRegionCenter(page, region, BASIC_TEST_PATTERN);
+
+      await expect
+        .poll(async () =>
+          page.evaluate(() => window.capyGenerator.getState().filled.size)
+        )
+        .toBe(index + 1);
+
+      const isLastFill = index + 1 === BASIC_TEST_PATTERN.regions.length;
+      const expectedStatus = isLastFill ? 'All done!' : 'Keep colouring';
+      await expect(progress).toHaveText(expectedStatus);
+    }
+
+    await page.click('#resetButton');
+    await expect(progress).toHaveText('Ready to colour');
+
+    await page.click('#helpButton');
+    await expect(page.locator('#debugLog .log-entry span').first()).toHaveText(/Reset puzzle progress/);
+    await page.click('[data-sheet-close="help"]');
   });
 });


### PR DESCRIPTION
## Summary
- collapse the command rail into icon-sized buttons that wrap safely on narrow screens
- streamline the palette dock with status-based progress messaging and wheel-to-scroll support
- harden the browser zoom guard, reset flows, and update docs/tests to reflect the trimmed HUD

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68e55c8c666c83319f3ac8a9a3596646